### PR TITLE
Add logo icons for table links

### DIFF
--- a/app.js
+++ b/app.js
@@ -118,7 +118,7 @@ function buildTable(items){
   if (!wrap) return;
 
   const headers = ['Nom latin (score %)', "FloreAlpes", "INPN statut", "Écologie", "Flora Gallica", "OpenObs", "Biodiv'AURA", "Info Flora", "Fiche synthèse"];
-  const link = (url, label) => url ? `<a href="${url}" target="_blank" rel="noopener">${label}</a>` : "—";
+  const linkIcon = (url, img, alt) => url ? `<a href="${url}" target="_blank" rel="noopener"><img src="assets/${img}" alt="${alt}" class="logo-icon"></a>` : "—";
 
   const rows = items.map(item => {
     const pct = item.score !== undefined ? `${Math.round(item.score * 100)}%` : "N/A";
@@ -131,17 +131,17 @@ function buildTable(items){
     if (tocEntry?.pdfFile && tocEntry?.page) {
       const pdfPath = `assets/flora_gallica_pdfs/${tocEntry.pdfFile}`;
       const viewerUrl = `viewer.html?file=${encodeURIComponent(pdfPath)}&page=${tocEntry.page}`;
-      floraGallicaLink = `<a href="${viewerUrl}" target="_blank" rel="noopener" title="Ouvrir Flora Gallica pour le genre ${genus}">Page ${tocEntry.page}</a>`;
+      floraGallicaLink = linkIcon(viewerUrl, "Flora Gallica.png", "Flora Gallica");
     }
     const normalizedSci = norm(sci);
     let floreAlpesLink = "—";
     const foundKey = Object.keys(floreAlpesIndex).find(key => norm(key.split('(')[0]) === normalizedSci);
     if (foundKey) {
         const urlPart = floreAlpesIndex[foundKey].split('?')[0];
-        floreAlpesLink = link(`https://www.florealpes.com/${urlPart}`, "fiche");
+        floreAlpesLink = linkIcon(`https://www.florealpes.com/${urlPart}`, "FloreAlpes.png", "FloreAlpes");
     }
     const escapedSci = sci.replace(/'/g, "\\'");
-    return `<tr><td class="col-nom-latin">${sci}<br><span class="score">(${pct})</span></td><td class="col-link">${floreAlpesLink}</td><td class="col-link">${link(cd && inpnStatut(cd),"statut")}</td><td class="col-ecologie">${eco}</td><td class="col-link">${floraGallicaLink}</td><td class="col-link">${link(cd && openObs(cd),"carte")}</td><td class="col-link">${link(cd && aura(cd),"atlas")}</td><td class="col-link">${link(infoFlora(sci),"fiche")}</td><td class="col-link"><a href="#" onclick="handleSynthesisClick(event, this, '${escapedSci}')">Générer</a></td></tr>`;
+    return `<tr><td class="col-nom-latin">${sci}<br><span class="score">(${pct})</span></td><td class="col-link">${floreAlpesLink}</td><td class="col-link">${linkIcon(cd && inpnStatut(cd), "INPN.png", "INPN")}</td><td class="col-ecologie">${eco}</td><td class="col-link">${floraGallicaLink}</td><td class="col-link">${linkIcon(cd && openObs(cd), "OpenObs.png", "OpenObs")}</td><td class="col-link">${linkIcon(cd && aura(cd), "Biodiv'AURA.png", "Biodiv'AURA")}</td><td class="col-link">${linkIcon(infoFlora(sci), "Info Flora.png", "Info Flora")}</td><td class="col-link"><a href="#" onclick="handleSynthesisClick(event, this, '${escapedSci}')"><img src="assets/Audio.png" alt="Audio" class="logo-icon"></a></td></tr>`;
   }).join("");
 
   const headerHtml = `<tr><th class="col-nom-latin">Nom latin (score %)</th><th class="col-link">FloreAlpes</th><th class="col-link">INPN statut</th><th class="col-ecologie">Écologie</th><th class="col-link">Flora Gallica</th><th class="col-link">OpenObs</th><th class="col-link">Biodiv'AURA</th><th class="col-link">Info Flora</th><th class="col-link">Fiche synthèse</th></tr>`;

--- a/index.html
+++ b/index.html
@@ -39,6 +39,7 @@
     .col-nom-latin .score { display:block; font-size:0.9em; color:#555; }
     .col-ecologie { width: 36%; }
     .col-link { width: 6%; text-align: center; }
+    .logo-icon { width: 24px; height: auto; }
     td a{color:var(--primary);text-decoration:none}
     td a:hover{text-decoration:underline}
     details{margin-bottom:1rem;background:var(--card);border:1px solid var(--border);border-radius:6px;box-shadow:0 2px 6px rgba(0,0,0,.05);}


### PR DESCRIPTION
## Summary
- add `.logo-icon` CSS rule in index.html
- show logos instead of link text in results table

## Testing
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_6842f05d8854832cb10ce71bdba5435e