### PR TITLE
Fix iOS PDF viewer fallback

### DIFF
--- a/app.js
+++ b/app.js
@@ -46,6 +46,7 @@ const inpnStatut = c => `https://inpn.mnhn.fr/espece/cd_nom/${c}/tab/statut`;
 const aura       = c => `https://atlas.biodiversite-auvergne-rhone-alpes.fr/espece/${c}`;
 const openObs    = c => `https://openobs.mnhn.fr/openobs-hub/occurrences/search?q=lsid%3A${c}%20AND%20(dynamicProperties_diffusionGP%3A%22true%22)&qc=&radius=120.6&lat=45.188529&lon=5.724524#tab_mapView`;
 const pfaf       = n => `https://pfaf.org/user/Plant.aspx?LatinName=${encodeURIComponent(n).replace(/%20/g, '+')}`;
+const isIOS = () => /iPad|iPhone|iPod/.test(navigator.userAgent);
 // Enregistre une photo sur l'appareil en declenchant un telechargement
 function savePhotoLocally(blob, name = "photo.jpg") {
   try {
@@ -158,8 +159,13 @@ function buildTable(items){
     let floraGallicaLink = "—";
     if (tocEntry?.pdfFile && tocEntry?.page) {
       const pdfPath = `assets/flora_gallica_pdfs/${tocEntry.pdfFile}`;
-      const viewerUrl = `viewer.html?file=${encodeURIComponent(pdfPath)}&page=${tocEntry.page}`;
-      floraGallicaLink = linkIcon(viewerUrl, "Flora Gallica.png", "Flora Gallica");
+      if (isIOS()) {
+        const directUrl = `${pdfPath}#page=${tocEntry.page}`;
+        floraGallicaLink = linkIcon(directUrl, "Flora Gallica.png", "Flora Gallica");
+      } else {
+        const viewerUrl = `viewer.html?file=${encodeURIComponent(pdfPath)}&page=${tocEntry.page}`;
+        floraGallicaLink = linkIcon(viewerUrl, "Flora Gallica.png", "Flora Gallica");
+      }
     }
     const normalizedSci = norm(sci);
     let floreAlpesLink = "—";

--- a/assets/viewer_app.js
+++ b/assets/viewer_app.js
@@ -2,6 +2,16 @@ import * as pdfjsLib from '../pdfjs/build/pdf.mjs';
 
 pdfjsLib.GlobalWorkerOptions.workerSrc = `../pdfjs/build/pdf.worker.mjs`;
 
+function supportsModuleWorker() {
+    try {
+        const worker = new Worker(URL.createObjectURL(new Blob([''], {type:'text/javascript'})), {type:'module'});
+        worker.terminate();
+        return true;
+    } catch (e) {
+        return false;
+    }
+}
+
 // Récupération des éléments du DOM
 const canvas = document.getElementById('pdf-canvas');
 const ctx = canvas.getContext('2d');
@@ -86,6 +96,13 @@ async function loadPdfViewer() {
     const urlParams = new URLSearchParams(window.location.search);
     const pdfUrl = urlParams.get('file');
     const initialPage = parseInt(urlParams.get('page'), 10) || 1;
+
+    if (!supportsModuleWorker()) {
+        if (pdfUrl) {
+            location.href = `${pdfUrl}#page=${initialPage}`;
+            return;
+        }
+    }
 
     if (!pdfUrl) {
         document.body.innerHTML = '<h1>Erreur : Aucun fichier PDF spécifié.</h1>';


### PR DESCRIPTION
## Summary
- detect iOS devices in the app
- open Flora Gallica PDFs directly on iOS instead of using the custom viewer
- add module worker support check in `viewer_app.js` and redirect to the PDF when unsupported

## Testing
- `pip install -r requirements.txt`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6843e3906144832c8828edd21114e4c5