### PR TITLE
Remove extraneous species cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -97,7 +97,6 @@
         <div class="option-container search-species-container"><h2>Recherche par nom</h2><input type="search" id="species-search-input" placeholder="Nom de l'espèce..."><button type="button" id="species-search-button" class="action-button">Rechercher</button></div>
         <div class="option-container search-species-container"><h2>Recherche par genre</h2><input type="search" id="genus-search-input" placeholder="Nom du genre..."><button type="button" id="genus-search-button" class="action-button">Rechercher</button></div>
         <div id="results"></div>
-        <div id="cards"></div>
     </div>
 
     <div id="synthesis-modal" class="synthesis-modal-overlay">

--- a/organ.html
+++ b/organ.html
@@ -45,6 +45,5 @@
     <button type="button" data-organ="fruit">Fruit</button>
   </div>
   <div id="results"></div>
-  <div id="cards"></div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- keep table view of PlantNet results
- remove the per-species card section from results pages

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6843e4a9f148832c9c3d739c3f36f2f3