### PR TITLE
Add global spinner for API requests

### DIFF
--- a/ui.js
+++ b/ui.js
@@ -9,7 +9,11 @@
 #modal-overlay.show{display:flex;}
 #modal-overlay .modal-content{background:var(--card,#fff);color:var(--text,#000);padding:1rem 1.5rem;border-radius:6px;max-width:500px;width:100%;}
 #modal-overlay .modal-close{float:right;cursor:pointer;background:none;border:none;font-size:1.5rem;}
-`; 
+#spinner-overlay{position:fixed;top:0;left:0;width:100%;height:100%;display:none;align-items:center;justify-content:center;background:rgba(0,0,0,.4);z-index:3500;}
+#spinner-overlay.show{display:flex;}
+#spinner-overlay .spinner{width:48px;height:48px;border:4px solid var(--border,#e0e0e0);border-top-color:var(--primary,#388e3c);border-radius:50%;animation:spin 1s linear infinite;}
+@keyframes spin{to{transform:rotate(360deg);}}
+`;
   document.head.appendChild(style);
   document.addEventListener('DOMContentLoaded',()=>{
     const n=document.createElement('div');
@@ -20,6 +24,10 @@
     m.innerHTML='<div class="modal-content"><button class="modal-close" aria-label="Fermer">&times;</button><div class="modal-body"></div></div>';
     document.body.appendChild(m);
     m.querySelector('.modal-close').addEventListener('click',()=>m.classList.remove('show'));
+    const s=document.createElement('div');
+    s.id='spinner-overlay';
+    s.innerHTML='<div class="spinner"></div>';
+    document.body.appendChild(s);
   });
   window.showNotification=function(message,type='info'){
     const c=document.getElementById('notification-container');
@@ -30,5 +38,9 @@
   window.showModal=function(message){
     const o=document.getElementById('modal-overlay');
     if(!o)return;o.querySelector('.modal-body').textContent=message;o.classList.add('show');
+  };
+  window.toggleSpinner=function(show){
+    const s=document.getElementById('spinner-overlay');
+    if(!s)return; s.classList.toggle('show', !!show);
   };
 })();


### PR DESCRIPTION
## Summary
- add spinner overlay and toggle function to UI
- create `apiFetch` helper wrapping fetch with spinner
- update main API calls to use the new helper

## Testing
- `npm test` *(fails: could not find package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6845d21fbee4832ca5f403fb39b3322f