### PR TITLE
Add shared stylesheet with spinner

### DIFF
--- a/contexte.html
+++ b/contexte.html
@@ -6,14 +6,13 @@
   <title>Contexte environnemental - Plantouille express</title>
   <link rel="manifest" href="manifest.json">
   <link rel="icon" href="icons/icon-192.png">
+  <link rel="stylesheet" href="style.css">
   <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />
   <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
   <script defer src="ui.js"></script>
   <script defer src="contexte.js"></script>
   <style>
-    :root{ --primary:#388e3c; --bg:#f6f9fb; --card:#ffffff; --border:#e0e0e0; --text:#202124; }
-    *{box-sizing:border-box;}
-    body{ background:var(--bg); color:var(--text); font-family:system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif; margin:0; padding:0; display:flex; flex-direction:column; min-height:100vh; }
+    body{ margin:0; padding:0; display:flex; flex-direction:column; min-height:100vh; }
     
     /* Navigation par onglets */
     .tabs-container { background: var(--card); box-shadow: 0 2px 4px rgba(0,0,0,0.1); position: sticky; top: 0; z-index: 100; }
@@ -54,14 +53,11 @@
     
     /* Chargement */
     .loading { display: none; text-align: center; margin: 2rem 0; }
-    .loading::after { content: ''; display: inline-block; width: 30px; height: 30px; border: 3px solid var(--border); border-top-color: var(--primary); border-radius: 50%; animation: spin 1s linear infinite; }
-    @keyframes spin { to { transform: rotate(360deg); } }
     
     /* Message d'instruction sur la carte */
     .map-instruction { display: none; position: absolute; top: 10px; left: 50%; transform: translateX(-50%); background: rgba(0, 0, 0, 0.7); color: white; padding: 8px 16px; border-radius: 20px; font-size: 14px; z-index: 1000; pointer-events: none; }
     
-    @media (prefers-color-scheme:dark) { 
-      :root{--bg:#181a1b;--card:#262b2f;--border:#333;--text:#ececec} 
+    @media (prefers-color-scheme:dark) {
       .coordinates-display { background: rgba(56, 142, 60, 0.2); }
       .map-instruction { background: rgba(255, 255, 255, 0.15); }
     }
@@ -115,7 +111,7 @@
     </div>
     
     <!-- Indicateur de chargement -->
-    <div class="loading" id="loading"></div>
+    <div class="loading loading-spinner" id="loading"></div>
     
     <!-- Section des résultats -->
     <div class="results-section" id="results-section">

--- a/index.html
+++ b/index.html
@@ -6,13 +6,12 @@
   <title>Plantouille express</title>
   <link rel="manifest" href="manifest.json">
   <link rel="icon" href="icons/icon-192.png">
+  <link rel="stylesheet" href="style.css">
   <script defer src="ui.js"></script>
   <script defer src="app.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
   <script defer src="notebook.js"></script>
   <style>
-    :root{ --primary:#388e3c; --bg:#f6f9fb; --card:#ffffff; --border:#e0e0e0; --text:#202124; }
-    *{box-sizing:border-box;}
     
     /* NOUVEAU : Styles pour la navigation par onglets */
     .tabs-container { background: var(--card); box-shadow: 0 2px 4px rgba(0,0,0,0.1); position: sticky; top: 0; z-index: 100; }
@@ -28,7 +27,7 @@
     body.home .tabs-container { position: fixed; top: 0; left: 0; right: 0; }
     body.home #main-content { margin-top: 60px; } /* Espace pour les onglets */
     
-    body{ background:var(--bg); color:var(--text); font-family:system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif; margin:0 auto; padding:1.2rem; max-width:1100px; }
+    body{ margin:0 auto; padding:1.2rem; max-width:1100px; }
     h1{margin:0 0 1.5rem;font-size:1.8rem;color:var(--primary)}
     .option-container { margin-bottom: 1.5rem; padding: 1rem; background-color: rgba(255, 255, 255, 0.8); border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); width: 90vw; max-width: 450px; }
     .option-container h2 { font-size: 1.2rem; color: var(--primary); margin-top: 0; margin-bottom: 0.8rem; }
@@ -76,8 +75,7 @@
     #synthesis-modal-body { margin-top: 15px; }
     #synthesis-modal-footer { margin-top: 20px; text-align: center; }
 
-    @media (prefers-color-scheme:dark){ 
-      :root{--bg:#181a1b;--card:#262b2f;--border:#333;--text:#ececec} 
+    @media (prefers-color-scheme:dark){
       .tabs-container { background: var(--card); }
       .tab:hover { background: rgba(56, 142, 60, 0.2); }
       table,details{border-color:#333} th{background:#262b2f;color:#ececec} body.home .upload-btn.logo-btn span { color: var(--text); } .option-container { background-color: rgba(38, 43, 47, 0.8); } #multi-image-list-area .image-organ-item { background-color: var(--card); border-color: var(--border); } #multi-image-list-area select { background-color: #333; color: var(--text); } .col-nom-latin .score { color:#ccc; } .col-criteres { color: #ccc; } .col-physionomie { color:#ccc; } #multi-image-list-area .delete-file-btn { color: #ff6b6b; } #multi-image-list-area .delete-file-btn:hover { color: #ff8787; } .search-species-container input[type="search"] { background-color: #333; color: var(--text); border-color: #555; }

--- a/notebook.html
+++ b/notebook.html
@@ -6,13 +6,12 @@
   <title>Carnet d'observations - Plantouille express</title>
   <link rel="manifest" href="manifest.json">
   <link rel="icon" href="icons/icon-192.png">
+  <link rel="stylesheet" href="style.css">
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
   <script defer src="ui.js"></script>
   <script defer src="notebook.js"></script>
   <style>
-    :root{ --primary:#388e3c; --bg:#f6f9fb; --card:#ffffff; --border:#e0e0e0; --text:#202124; }
-    *{box-sizing:border-box;}
-    body{ background:var(--bg); color:var(--text); font-family:system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif; margin:0; padding:0; display:flex; flex-direction:column; min-height:100vh; }
+    body{ margin:0; padding:0; display:flex; flex-direction:column; min-height:100vh; }
     .tabs-container{ background:var(--card); box-shadow:0 2px 4px rgba(0,0,0,0.1); position:sticky; top:0; z-index:100; }
     .tabs{ display:flex; border-bottom:2px solid var(--border); }
     .tab{ flex:1; padding:1rem; text-align:center; cursor:pointer; background:none; border:none; font-size:1rem; color:var(--text); transition:all 0.3s; position:relative; }

--- a/organ.html
+++ b/organ.html
@@ -8,13 +8,12 @@
 
   <link rel="manifest" href="manifest.json">
   <link rel="icon" href="icons/icon-192.png">
+  <link rel="stylesheet" href="style.css">
   <script defer src="ui.js"></script>
   <script defer src="app.js"></script>
   <style>
-    :root{--primary:#388e3c;--bg:#f6f9fb;--card:#ffffff;--border:#e0e0e0;--text:#202124}
-    *{box-sizing:border-box;}
     /* MODIFICATION : Le body prend toute la largeur, suppression de max-width et margin:auto */
-    body{background:var(--bg);color:var(--text);font-family:system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;margin:0;padding:1.2rem;}
+    body{margin:0;padding:1.2rem;}
     h1{margin:0 0 1rem;font-size:1.6rem;color:var(--primary)}
     #preview{max-width:100%;height:auto;display:block;margin:0 auto 1rem;}
     #organ-choice{text-align:center;margin:1rem 0;}
@@ -62,7 +61,7 @@
     summary:hover{background:rgba(0,0,0,.04);}
     .iframe-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(320px,1fr));gap:12px;padding:12px;}
     iframe{width:100%;height:280px;border:none;border-radius:4px;}
-    @media (prefers-color-scheme:dark){:root{--bg:#181a1b;--card:#262b2f;--border:#333;--text:#ececec}table,details{border-color:#333}th{background:#262b2f;color:#ececec}}
+    @media (prefers-color-scheme:dark){table,details{border-color:#333}th{background:#262b2f;color:#ececec}}
   </style>
 </head>
 <body class="home">

--- a/style.css
+++ b/style.css
@@ -1,0 +1,44 @@
+:root {
+  --primary:#388e3c;
+  --bg:#f6f9fb;
+  --card:#ffffff;
+  --border:#e0e0e0;
+  --text:#202124;
+  --font-family:system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  background: var(--bg);
+  color: var(--text);
+  font-family: var(--font-family);
+  margin: 0;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg:#181a1b;
+    --card:#262b2f;
+    --border:#333;
+    --text:#ececec;
+  }
+}
+
+.loading-spinner {
+  width: 40px;
+  height: 40px;
+  border: 4px solid var(--border);
+  border-top-color: var(--primary);
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+  margin: 2rem auto;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+
+@media (max-width: 600px) {
+  h1 { font-size: 1.4rem; }
+}

--- a/viewer.html
+++ b/viewer.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Lecteur de PDF - Flora Gallica</title>
+    <link rel="stylesheet" href="style.css">
     <style>
         * {
             box-sizing: border-box;


### PR DESCRIPTION
## Summary
- add global `style.css` for colors, fonts and responsive rules
- reference the new stylesheet in all html pages
- use `loading-spinner` class in `contexte.html`

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6845d214b7c4832c8c1795a9951d36d2