### PR TITLE
Update Gemini model to 2.5

### DIFF
--- a/app.js
+++ b/app.js
@@ -9,7 +9,8 @@ const MAX_MULTI_IMAGES = 5;
 // NOUVEAU : Ajout des clés et points d'accès pour les API Google
 const GEMINI_API_KEY = "AIzaSyDDv4amCchpTXGqz6FGuY8mxPClkw-uwMs";
 const TTS_API_KEY = "AIzaSyCsmQ_n_JtrA1Ev2GkOZeldYsAmHpJvhZY";
-const GEMINI_ENDPOINT = `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key=${GEMINI_API_KEY}`;
+// Mise à jour pour utiliser le modèle Gemini 2.5 Flash
+const GEMINI_ENDPOINT = `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash-preview-05-20:generateContent?key=${GEMINI_API_KEY}`;
 const TTS_ENDPOINT = `https://texttospeech.googleapis.com/v1/text:synthesize?key=${TTS_API_KEY}`;
 
 


### PR DESCRIPTION
## Summary
- use Gemini 2.5 Flash model for content generation

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68466d864f8c832caac75ce6cbce09cb