### PR TITLE
Register service worker for offline use

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ The notebook feature relies on a Supabase backend for authentication and storage
 
 1. Serve the project from a local HTTP server (for example using `npx serve` or `python3 -m http.server`).
 2. Open `http://localhost:PORT/index.html` in your browser. Service workers require an HTTP context, so opening the file directly will not work.
-3. For serverless functions, install Netlify CLI and run:
+3. The application automatically registers `sw.js` via `sw-register.js` to cache core assets for offline use.
+4. For serverless functions, install Netlify CLI and run:
 
 ```bash
 npm install -g netlify-cli

--- a/contexte.html
+++ b/contexte.html
@@ -10,6 +10,7 @@
   <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
   <script defer src="ui.js"></script>
   <script defer src="contexte.js"></script>
+  <script defer src="sw-register.js"></script>
   <style>
     :root{ --primary:#388e3c; --bg:#f6f9fb; --card:#ffffff; --border:#e0e0e0; --text:#202124; }
     html[data-theme="dark"]{ --bg:#181a1b; --card:#262b2f; --border:#333; --text:#ececec; }

--- a/index.html
+++ b/index.html
@@ -10,6 +10,7 @@
   <script defer src="app.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
   <script defer src="notebook.js"></script>
+  <script defer src="sw-register.js"></script>
   <style>
     :root{ --primary:#388e3c; --bg:#f6f9fb; --card:#ffffff; --border:#e0e0e0; --text:#202124; }
     html[data-theme="dark"]{ --bg:#181a1b; --card:#262b2f; --border:#333; --text:#ececec; }

--- a/notebook.html
+++ b/notebook.html
@@ -9,6 +9,7 @@
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
   <script defer src="ui.js"></script>
   <script defer src="notebook.js"></script>
+  <script defer src="sw-register.js"></script>
   <style>
     :root{ --primary:#388e3c; --bg:#f6f9fb; --card:#ffffff; --border:#e0e0e0; --text:#202124; }
     html[data-theme="dark"]{ --bg:#181a1b; --card:#262b2f; --border:#333; --text:#ececec; }

--- a/organ.html
+++ b/organ.html
@@ -10,6 +10,7 @@
   <link rel="icon" href="icons/icon-192.png">
   <script defer src="ui.js"></script>
   <script defer src="app.js"></script>
+  <script defer src="sw-register.js"></script>
   <style>
     :root{--primary:#388e3c;--bg:#f6f9fb;--card:#ffffff;--border:#e0e0e0;--text:#202124}
     html[data-theme="dark"]{--bg:#181a1b;--card:#262b2f;--border:#333;--text:#ececec}

--- a/sw-register.js
+++ b/sw-register.js
@@ -1,0 +1,7 @@
+if ('serviceWorker' in navigator) {
+  window.addEventListener('load', () => {
+    navigator.serviceWorker.register('./sw.js')
+      .then(reg => console.log('Service Worker registered:', reg.scope))
+      .catch(err => console.error('Service Worker registration failed:', err));
+  });
+}

--- a/viewer.html
+++ b/viewer.html
@@ -97,6 +97,7 @@
 
     <script src="pdfjs/build/pdf.mjs" type="module"></script>
     <script src="assets/viewer_app.js" type="module"></script>
+    <script src="sw-register.js"></script>
 
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add `sw-register.js` for service worker registration
- load this script in all HTML pages
- mention automatic registration in README

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6845d1830378832c96bcc699080a03fe