### PR TITLE
Centralize shared styles

### DIFF
--- a/contexte.html
+++ b/contexte.html
@@ -7,22 +7,12 @@
   <link rel="manifest" href="manifest.json">
   <link rel="icon" href="icons/icon-192.png">
   <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />
+  <link rel="stylesheet" href="style.css">
   <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
   <script defer src="ui.js"></script>
   <script defer src="contexte.js"></script>
   <style>
-    :root{ --primary:#388e3c; --bg:#f6f9fb; --card:#ffffff; --border:#e0e0e0; --text:#202124; }
-    html[data-theme="dark"]{ --bg:#181a1b; --card:#262b2f; --border:#333; --text:#ececec; }
-    *{box-sizing:border-box;}
     body{ background:var(--bg); color:var(--text); font-family:system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif; margin:0; padding:0; display:flex; flex-direction:column; min-height:100vh; }
-    
-    /* Navigation par onglets */
-    .tabs-container { background: var(--card); box-shadow: 0 2px 4px rgba(0,0,0,0.1); position: sticky; top: 0; z-index: 100; display:flex; align-items:center; justify-content:space-between; }
-    .tabs { display: flex; border-bottom: 2px solid var(--border); flex-grow:1; }
-    .tab { flex: 1; padding: 1rem; text-align: center; cursor: pointer; background: none; border: none; font-size: 1rem; color: var(--text); transition: all 0.3s; position: relative; }
-    .tab:hover { background: rgba(56, 142, 60, 0.1); }
-    .tab.active { color: var(--primary); font-weight: 600; }
-    .tab.active::after { content: ''; position: absolute; bottom: -2px; left: 0; right: 0; height: 2px; background: var(--primary); }
     
     /* Contenu principal */
     .main-content { flex: 1; padding: 1.5rem; max-width: 900px; margin: 0 auto; width: 100%; }
@@ -33,9 +23,6 @@
     .location-card { background: var(--card); border-radius: 8px; padding: 1.5rem; box-shadow: 0 2px 6px rgba(0,0,0,0.1); }
     .location-card h2 { font-size: 1.2rem; color: var(--primary); margin: 0 0 1rem; }
     
-    .action-button { padding: 12px 20px; background: var(--primary); color: white; border: none; border-radius: 6px; font-size: 1rem; cursor: pointer; transition: all 0.3s; width: 100%; }
-    .action-button:hover { background: #2e7d32; transform: scale(1.02); }
-    .action-button:disabled { background: #ccc; cursor: not-allowed; transform: none; }
     
     /* Carte interactive */
     #map-container { display: none; margin-top: 1rem; border-radius: 8px; overflow: hidden; box-shadow: 0 2px 6px rgba(0,0,0,0.1); }
@@ -62,12 +49,9 @@
     .map-instruction { display: none; position: absolute; top: 10px; left: 50%; transform: translateX(-50%); background: rgba(0, 0, 0, 0.7); color: white; padding: 8px 16px; border-radius: 20px; font-size: 14px; z-index: 1000; pointer-events: none; }
     
     @media (prefers-color-scheme:dark) {
-      :root{--bg:#181a1b;--card:#262b2f;--border:#333;--text:#ececec}
       .coordinates-display { background: rgba(56, 142, 60, 0.2); }
       .map-instruction { background: rgba(255, 255, 255, 0.15); }
     }
-    #theme-toggle{background:none;border:none;cursor:pointer;font-size:1.2rem;color:var(--text);padding:0 1rem;}
-    #theme-toggle:hover{transform:scale(1.1);}
   </style>
 </head>
 <body>

--- a/index.html
+++ b/index.html
@@ -6,25 +6,12 @@
   <title>Plantouille express</title>
   <link rel="manifest" href="manifest.json">
   <link rel="icon" href="icons/icon-192.png">
+  <link rel="stylesheet" href="style.css">
   <script defer src="ui.js"></script>
   <script defer src="app.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
   <script defer src="notebook.js"></script>
   <style>
-    :root{ --primary:#388e3c; --bg:#f6f9fb; --card:#ffffff; --border:#e0e0e0; --text:#202124; }
-    html[data-theme="dark"]{ --bg:#181a1b; --card:#262b2f; --border:#333; --text:#ececec; }
-    *{box-sizing:border-box;}
-    
-    /* NOUVEAU : Styles pour la navigation par onglets */
-    .tabs-container { background: var(--card); box-shadow: 0 2px 4px rgba(0,0,0,0.1); position: sticky; top: 0; z-index: 100; display:flex; align-items:center; justify-content:space-between; }
-    .tabs { display: flex; border-bottom: 2px solid var(--border); flex-grow:1; }
-    .tab { flex: 1; padding: 1rem; text-align: center; cursor: pointer; background: none; border: none; font-size: 1rem; color: var(--text); transition: all 0.3s; position: relative; }
-    .tab:hover { background: rgba(56, 142, 60, 0.1); }
-    .tab.active { color: var(--primary); font-weight: 600; }
-    .tab.active::after { content: ''; position: absolute; bottom: -2px; left: 0; right: 0; height: 2px; background: var(--primary); }
-
-    #theme-toggle{ background:none; border:none; cursor:pointer; font-size:1.2rem; color:var(--text); padding:0 1rem; }
-    #theme-toggle:hover{ transform:scale(1.1); }
     
     /* Ajustement du body pour les onglets */
     body.home::before{ content:""; position:fixed; inset:0; background:url("assets/Bandeau.jpg") center/cover no-repeat fixed; z-index:-1; opacity:.30; }
@@ -36,11 +23,6 @@
     h1{margin:0 0 1.5rem;font-size:1.8rem;color:var(--primary)}
     .option-container { margin-bottom: 1.5rem; padding: 1rem; background-color: rgba(255, 255, 255, 0.8); border-radius: 8px; box-shadow: 0 2px 4px rgba(0,0,0,0.1); width: 90vw; max-width: 450px; }
     .option-container h2 { font-size: 1.2rem; color: var(--primary); margin-top: 0; margin-bottom: 0.8rem; }
-    .upload-btn, .action-button { display:block; width:100%; padding: 10px 15px; margin-top: 0.5rem; cursor:pointer; border: 1px solid var(--primary); background-color: var(--primary); color: white; border-radius: 6px; font-size: 1rem; text-align: center; transition: background-color .15s, transform .15s; }
-    .upload-btn:hover, .action-button:hover { background-color: #2e7d32; transform: scale(1.03); }
-    .upload-btn.logo-btn { background-color: transparent; border: none; padding: 0; }
-    .upload-btn.logo-btn img { width: 100%; max-width: 220px; height: auto; display: block; margin: 0 auto 0.5rem auto; }
-    .upload-btn.logo-btn span { display: block; margin-top: 0.3rem; font-size: 0.9rem; color: var(--text); }
     body.home .upload-btn.logo-btn:hover img { transform:scale(1.05); }
     .search-species-container input[type="search"] { width: calc(100% - 22px); padding: 10px; margin-bottom: 0.5rem; border: 1px solid var(--border); border-radius: 6px; font-size: 1rem; }
     #multi-image-list-area .image-organ-item { display: flex; align-items: center; justify-content: space-between; margin-bottom: 0.6rem; padding: 0.6rem; border: 1px solid var(--border); border-radius: 4px; background-color: var(--card); font-size: 0.9rem; }
@@ -82,7 +64,6 @@
     #synthesis-modal-footer { margin-top: 20px; text-align: center; }
 
     @media (prefers-color-scheme:dark){ 
-      :root{--bg:#181a1b;--card:#262b2f;--border:#333;--text:#ececec} 
       .tabs-container { background: var(--card); }
       .tab:hover { background: rgba(56, 142, 60, 0.2); }
       table,details{border-color:#333} th{background:#262b2f;color:#ececec} body.home .upload-btn.logo-btn span { color: var(--text); } .option-container { background-color: rgba(38, 43, 47, 0.8); } #multi-image-list-area .image-organ-item { background-color: var(--card); border-color: var(--border); } #multi-image-list-area select { background-color: #333; color: var(--text); } .col-nom-latin .score { color:#ccc; } .col-criteres { color: #ccc; } .col-physionomie { color:#ccc; } #multi-image-list-area .delete-file-btn { color: #ff6b6b; } #multi-image-list-area .delete-file-btn:hover { color: #ff8787; } .search-species-container input[type="search"] { background-color: #333; color: var(--text); border-color: #555; }

--- a/notebook.html
+++ b/notebook.html
@@ -7,19 +7,11 @@
   <link rel="manifest" href="manifest.json">
   <link rel="icon" href="icons/icon-192.png">
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
+  <link rel="stylesheet" href="style.css">
   <script defer src="ui.js"></script>
   <script defer src="notebook.js"></script>
   <style>
-    :root{ --primary:#388e3c; --bg:#f6f9fb; --card:#ffffff; --border:#e0e0e0; --text:#202124; }
-    html[data-theme="dark"]{ --bg:#181a1b; --card:#262b2f; --border:#333; --text:#ececec; }
-    *{box-sizing:border-box;}
     body{ background:var(--bg); color:var(--text); font-family:system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif; margin:0; padding:0; display:flex; flex-direction:column; min-height:100vh; }
-    .tabs-container{ background:var(--card); box-shadow:0 2px 4px rgba(0,0,0,0.1); position:sticky; top:0; z-index:100; display:flex; align-items:center; justify-content:space-between; }
-    .tabs{ display:flex; border-bottom:2px solid var(--border); flex-grow:1; }
-    .tab{ flex:1; padding:1rem; text-align:center; cursor:pointer; background:none; border:none; font-size:1rem; color:var(--text); transition:all 0.3s; position:relative; }
-    .tab:hover{ background:rgba(56,142,60,0.1); }
-    .tab.active{ color:var(--primary); font-weight:600; }
-    .tab.active::after{ content:''; position:absolute; bottom:-2px; left:0; right:0; height:2px; background:var(--primary); }
 
     .main-content{ flex:1; padding:1.5rem; max-width:900px; margin:0 auto; width:100%; }
     h1{ margin:0 0 1.5rem; font-size:1.6rem; color:var(--primary); text-align:center; }
@@ -28,23 +20,14 @@
     form{ display:flex; flex-direction:column; gap:.75rem; margin-bottom:1rem; background:var(--card); padding:1.5rem; border-radius:8px; box-shadow:0 2px 6px rgba(0,0,0,0.1); }
     input{ padding:.6rem .8rem; border:1px solid var(--border); border-radius:4px; }
     button{ padding:.6rem 1rem; cursor:pointer; border:none; border-radius:6px; font-size:1rem; }
-    .action-button{ background:var(--primary); color:#fff; transition:all 0.3s; }
-    .action-button:hover{ background:#2e7d32; transform:scale(1.02); }
     #logout-btn{ margin-bottom:1rem; }
-    #theme-toggle{ background:none; border:none; cursor:pointer; font-size:1.2rem; color:var(--text); padding:0 1rem; }
-    #theme-toggle:hover{ transform:scale(1.1); }
-  </style>
-</head>
+</style>
 <body>
   <nav class="tabs-container">
     <div class="tabs">
-      <button class="tab" onclick="window.location.href='index.html'">Identification</button>
-      <button class="tab" onclick="window.location.href='contexte.html'">Contexte environnemental</button>
       <button class="tab active">Carnet</button>
     </div>
     <button id="theme-toggle" title="Basculer le thème">🌙</button>
-  </nav>
-
   <div class="main-content">
     <h1>Carnet d'observations</h1>
     <div id="auth-section">

--- a/organ.html
+++ b/organ.html
@@ -8,12 +8,10 @@
 
   <link rel="manifest" href="manifest.json">
   <link rel="icon" href="icons/icon-192.png">
+  <link rel="stylesheet" href="style.css">
   <script defer src="ui.js"></script>
   <script defer src="app.js"></script>
   <style>
-    :root{--primary:#388e3c;--bg:#f6f9fb;--card:#ffffff;--border:#e0e0e0;--text:#202124}
-    html[data-theme="dark"]{--bg:#181a1b;--card:#262b2f;--border:#333;--text:#ececec}
-    *{box-sizing:border-box;}
     /* MODIFICATION : Le body prend toute la largeur, suppression de max-width et margin:auto */
     body{background:var(--bg);color:var(--text);font-family:system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;margin:0;padding:1.2rem;}
     h1{margin:0 0 1rem;font-size:1.6rem;color:var(--primary)}
@@ -64,9 +62,6 @@
     summary:hover{background:rgba(0,0,0,.04);}
     .iframe-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(320px,1fr));gap:12px;padding:12px;}
     iframe{width:100%;height:280px;border:none;border-radius:4px;}
-    @media (prefers-color-scheme:dark){:root{--bg:#181a1b;--card:#262b2f;--border:#333;--text:#ececec}table,details{border-color:#333}th{background:#262b2f;color:#ececec}}
-    #theme-toggle{background:none;border:none;cursor:pointer;font-size:1.2rem;color:var(--text);padding:0 1rem;}
-    #theme-toggle:hover{transform:scale(1.1);}
   </style>
 </head>
 <body class="home">

--- a/style.css
+++ b/style.css
@@ -1,0 +1,113 @@
+:root{
+    --primary:#388e3c;
+    --bg:#f6f9fb;
+    --card:#ffffff;
+    --border:#e0e0e0;
+    --text:#202124;
+}
+html[data-theme="dark"]{
+    --bg:#181a1b;
+    --card:#262b2f;
+    --border:#333;
+    --text:#ececec;
+}
+*{box-sizing:border-box;}
+body{
+    background:var(--bg);
+    color:var(--text);
+    font-family:system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;
+    margin:0;
+}
+#theme-toggle{
+    background:none;
+    border:none;
+    cursor:pointer;
+    font-size:1.2rem;
+    color:var(--text);
+    padding:0 1rem;
+}
+#theme-toggle:hover{transform:scale(1.1);}
+.tabs-container{
+    background:var(--card);
+    box-shadow:0 2px 4px rgba(0,0,0,0.1);
+    position:sticky;
+    top:0;
+    z-index:100;
+    display:flex;
+    align-items:center;
+    justify-content:space-between;
+}
+.tabs{
+    display:flex;
+    border-bottom:2px solid var(--border);
+    flex-grow:1;
+}
+.tab{
+    flex:1;
+    padding:1rem;
+    text-align:center;
+    cursor:pointer;
+    background:none;
+    border:none;
+    font-size:1rem;
+    color:var(--text);
+    transition:all 0.3s;
+    position:relative;
+}
+.tab:hover{background:rgba(56,142,60,0.1);}
+.tab.active{
+    color:var(--primary);
+    font-weight:600;
+}
+.tab.active::after{
+    content:'';
+    position:absolute;
+    bottom:-2px;
+    left:0;
+    right:0;
+    height:2px;
+    background:var(--primary);
+}
+.action-button,
+.upload-btn{
+    display:block;
+    width:100%;
+    padding:10px 15px;
+    margin-top:0.5rem;
+    cursor:pointer;
+    border:1px solid var(--primary);
+    background-color:var(--primary);
+    color:white;
+    border-radius:6px;
+    font-size:1rem;
+    text-align:center;
+    transition:background-color .15s, transform .15s;
+}
+.action-button:hover,
+.upload-btn:hover{
+    background-color:#2e7d32;
+    transform:scale(1.03);
+}
+.action-button:disabled{
+    background:#ccc;
+    cursor:not-allowed;
+    transform:none;
+}
+.upload-btn.logo-btn{
+    background-color:transparent;
+    border:none;
+    padding:0;
+}
+.upload-btn.logo-btn img{
+    width:100%;
+    max-width:220px;
+    height:auto;
+    display:block;
+    margin:0 auto 0.5rem auto;
+}
+.upload-btn.logo-btn span{
+    display:block;
+    margin-top:0.3rem;
+    font-size:0.9rem;
+    color:var(--text);
+}


### PR DESCRIPTION
## Summary
- add `style.css` with common design tokens and components
- reference the shared stylesheet in each HTML page
- remove duplicated CSS from individual pages

## Testing
- `node --version`


------
https://chatgpt.com/codex/tasks/task_e_68466c41808c832cbd54d5c72afa08a9