### PR TITLE
Ajout d'une zone info adaptée au mobile

### DIFF
--- a/app.js
+++ b/app.js
@@ -448,7 +448,7 @@ function buildTable(items){
 
   const headerHtml = `<tr><th>Sél.</th><th>Nom latin (score %)</th><th>FloreAlpes</th><th>INPN statut</th><th>Critères physiologiques</th><th>Écologie</th><th>Physionomie</th><th>Flora Gallica</th><th>OpenObs</th><th>Biodiv'AURA</th><th>Info Flora</th><th>Fiche synthèse</th><th>PFAF</th></tr>`;
   
-  wrap.innerHTML = `<table><thead>${headerHtml}</thead><tbody>${rows}</tbody></table><div id="comparison-footer" style="padding-top: 1rem; text-align: center;"></div><div id="comparison-results-container" style="display:none;"></div>`;
+  wrap.innerHTML = `<div class="table-wrapper"><table><thead>${headerHtml}</thead><tbody>${rows}</tbody></table></div><div id="comparison-footer" style="padding-top: 1rem; text-align: center;"></div><div id="comparison-results-container" style="display:none;"></div>`;
 
   const footer = document.getElementById('comparison-footer');
   if (footer) {
@@ -478,9 +478,14 @@ function buildTable(items){
       const targetCell = e.target.closest('.text-popup-trigger');
       if (targetCell) {
           e.preventDefault();
-          const title = targetCell.dataset.title || 'Détails';
-          const fullText = decodeURIComponent(targetCell.dataset.fulltext);
-          showInfoModal(title, fullText);
+          const infoPanel = document.getElementById('info-panel');
+          if (infoPanel) {
+              const title = targetCell.dataset.title || '';
+              const fullText = decodeURIComponent(targetCell.dataset.fulltext);
+              infoPanel.innerHTML = `<h3 style="margin-top:0">${title}</h3><p>${fullText}</p>`;
+              infoPanel.style.display = 'block';
+              infoPanel.scrollIntoView({behavior:'smooth', block:'start'});
+          }
       }
   });
 }

--- a/organ.html
+++ b/organ.html
@@ -22,6 +22,7 @@
     #organ-choice{text-align:center;margin:1rem 0;}
     #organ-choice button{margin:.25rem;padding:.4rem .8rem;border:1px solid var(--primary);background:var(--primary);color:#fff;border-radius:4px;cursor:pointer;}
     
+    .table-wrapper{overflow-x:auto;}
     table{width:100%;border-collapse:collapse;background:var(--card);border:1px solid var(--border);border-radius:6px;box-shadow:0 2px 6px rgba(0,0,0,.05);margin-bottom:1.2rem;table-layout:auto;}
     
     th,td{padding:8px 10px;border-bottom:1px solid var(--border);vertical-align:middle;word-wrap:break-word;}
@@ -57,6 +58,8 @@
     }
     img.small-logo { height: 24px; width: auto; }
 
+    .info-panel{display:none;padding:1rem;background:var(--card);border:1px solid var(--border);border-radius:6px;margin-top:1rem;}
+
     details{margin-bottom:1rem;background:var(--card);border:1px solid var(--border);border-radius:6px;box-shadow:0 2px 6px rgba(0,0,0,.05);}
     summary{padding:10px 12px;cursor:pointer;font-weight:500;color:var(--primary);list-style:none;}
     summary::after{content:"▸";float:right;transition:transform .2s;}
@@ -84,5 +87,6 @@
     <button type="button" data-organ="fruit">Fruit</button>
   </div>
   <div id="results"></div>
+  <div id="info-panel" class="info-panel"></div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- ajoute un conteneur `info-panel` sous le tableau des résultats
- affiche le texte complet des colonnes au clic dans cette zone
- encapsule le tableau dans `.table-wrapper` pour le défilement horizontal

## Testing
- `node -c app.js`

------
https://chatgpt.com/codex/tasks/task_e_684731a1c758832c8cab58b9bf361d37