### PR TITLE
Enable easier horizontal scrolling on mobile results

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,6 +55,8 @@
     body:not(.home) h1 { font-size:1.6rem; color:var(--primary); margin-bottom: 1rem;}
     body:not(.home) .tabs-container { position: static; }
     table{ width:100%; table-layout: fixed; border-collapse:collapse; background:var(--card); border:1px solid var(--border); border-radius:6px; box-shadow:0 2px 6px rgba(0,0,0,.05); margin-bottom:1.2rem; }
+    #results{overflow-x:auto;}
+    #results::after{content:"";display:block;height:2rem;}
     th,td{ padding: 8px 6px; border-bottom:1px solid var(--border); word-wrap: break-word; vertical-align: top; }
     th{background:#fff;color:#000;font-weight:600;text-align:left}
     tr:last-child td{border-bottom:none}

--- a/organ.html
+++ b/organ.html
@@ -23,6 +23,8 @@
     #organ-choice button{margin:.25rem;padding:.4rem .8rem;border:1px solid var(--primary);background:var(--primary);color:#fff;border-radius:4px;cursor:pointer;}
     
     .table-wrapper{overflow-x:auto;}
+    #results{overflow-x:auto;}
+    #results::after{content:"";display:block;height:2rem;}
     table{width:100%;border-collapse:collapse;background:var(--card);border:1px solid var(--border);border-radius:6px;box-shadow:0 2px 6px rgba(0,0,0,.05);margin-bottom:1.2rem;table-layout:auto;}
     
     th,td{padding:8px 10px;border-bottom:1px solid var(--border);vertical-align:middle;word-wrap:break-word;}


### PR DESCRIPTION
## Summary
- allow whole results area to scroll horizontally
- add extra bottom space to help touch interaction

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847342759d8832ca7350ea2063b4a13