### PR TITLE
Enable easier mobile horizontal scroll

### DIFF
--- a/app.js
+++ b/app.js
@@ -76,6 +76,29 @@ const aura       = c => `https://atlas.biodiversite-auvergne-rhone-alpes.fr/espe
 const openObs    = c => `https://openobs.mnhn.fr/openobs-hub/occurrences/search?q=lsid%3A${c}%20AND%20(dynamicProperties_diffusionGP%3A%22true%22)&qc=&radius=120.6&lat=45.188529&lon=5.724524#tab_mapView`;
 const pfaf       = n => `https://pfaf.org/user/Plant.aspx?LatinName=${encodeURIComponent(n).replace(/%20/g, '+')}`;
 const isIOS = () => /iPad|iPhone|iPod/.test(navigator.userAgent);
+
+function enableDragScroll(el) {
+  if (!el) return;
+  let isDown = false;
+  let startX = 0;
+  let scrollLeft = 0;
+  el.addEventListener('pointerdown', e => {
+    if (e.pointerType !== 'touch') return;
+    isDown = true;
+    startX = e.clientX;
+    scrollLeft = el.scrollLeft;
+    el.setPointerCapture(e.pointerId);
+  });
+  el.addEventListener('pointermove', e => {
+    if (!isDown) return;
+    const dx = startX - e.clientX;
+    el.scrollLeft = scrollLeft + dx;
+  });
+  const stop = () => { isDown = false; };
+  el.addEventListener('pointerup', stop);
+  el.addEventListener('pointercancel', stop);
+  el.addEventListener('pointerleave', stop);
+}
 // Génère un nom de fichier basé sur la date et l'heure courantes
 function makeTimestampedName(prefix = "") {
   const d = new Date();
@@ -459,6 +482,7 @@ function buildTable(items){
   const headerHtml = `<tr><th>Sél.</th><th>Nom latin (score %)</th><th>FloreAlpes</th><th>INPN statut</th><th>Critères physiologiques</th><th>Écologie</th><th>Physionomie</th><th>Flora Gallica</th><th>OpenObs</th><th>Biodiv'AURA</th><th>Info Flora</th><th>Fiche synthèse</th><th>PFAF</th></tr>`;
   
   wrap.innerHTML = `<div class="table-wrapper"><table><thead>${headerHtml}</thead><tbody>${rows}</tbody></table></div><div id="comparison-footer" style="padding-top: 1rem; text-align: center;"></div><div id="comparison-results-container" style="display:none;"></div>`;
+  enableDragScroll(wrap);
 
   const footer = document.getElementById('comparison-footer');
   if (footer) {

--- a/index.html
+++ b/index.html
@@ -55,8 +55,8 @@
     body:not(.home) h1 { font-size:1.6rem; color:var(--primary); margin-bottom: 1rem;}
     body:not(.home) .tabs-container { position: static; }
     table{ width:100%; table-layout: fixed; border-collapse:collapse; background:var(--card); border:1px solid var(--border); border-radius:6px; box-shadow:0 2px 6px rgba(0,0,0,.05); margin-bottom:1.2rem; }
-    #results{overflow-x:auto;}
-    #results::after{content:"";display:block;height:2rem;}
+    #results{overflow-x:auto;-webkit-overflow-scrolling:touch;}
+    #results::after{content:"";display:block;height:6rem;}
     th,td{ padding: 8px 6px; border-bottom:1px solid var(--border); word-wrap: break-word; vertical-align: top; }
     th{background:#fff;color:#000;font-weight:600;text-align:left}
     tr:last-child td{border-bottom:none}

--- a/organ.html
+++ b/organ.html
@@ -22,9 +22,9 @@
     #organ-choice{text-align:center;margin:1rem 0;}
     #organ-choice button{margin:.25rem;padding:.4rem .8rem;border:1px solid var(--primary);background:var(--primary);color:#fff;border-radius:4px;cursor:pointer;}
     
-    .table-wrapper{overflow-x:auto;}
-    #results{overflow-x:auto;}
-    #results::after{content:"";display:block;height:2rem;}
+    .table-wrapper{overflow-x:auto;-webkit-overflow-scrolling:touch;}
+    #results{overflow-x:auto;-webkit-overflow-scrolling:touch;}
+    #results::after{content:"";display:block;height:6rem;}
     table{width:100%;border-collapse:collapse;background:var(--card);border:1px solid var(--border);border-radius:6px;box-shadow:0 2px 6px rgba(0,0,0,.05);margin-bottom:1.2rem;table-layout:auto;}
     
     th,td{padding:8px 10px;border-bottom:1px solid var(--border);vertical-align:middle;word-wrap:break-word;}


### PR DESCRIPTION
## Summary
- expand the scroll area below the results tables
- allow touch-drag scrolling anywhere in the results container

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847b73d0ac8832cb4ef8de270be2b0f