### PR TITLE
Resize home page logos

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,6 +39,8 @@
     .upload-btn:hover, .action-button:hover { background-color: #2e7d32; transform: scale(1.03); }
     .upload-btn.logo-btn { background-color: transparent; border: none; padding: 0; display: block; max-width: 300px; margin: 0 auto; }
     .upload-btn.logo-btn img { width: 100%; max-width: 300px; height: auto; display: block; margin: 0 auto 0.5rem auto; }
+    .camera-logo-btn { max-width: 150px; }
+    .gallery-logo-btn { max-width: 75px; margin-left: 0; margin-right: auto; }
     .upload-btn.logo-btn span { display: block; margin-top: 0.3rem; font-size: 0.9rem; color: var(--text); }
     body.home .upload-btn.logo-btn:hover img { transform:scale(1.05); }
     .home-actions{display:flex;flex-direction:column;align-items:center;gap:1rem;}
@@ -110,10 +112,10 @@
         <h1>Plante App</h1>
         <div class="home-actions">
             <input type="file" id="file-capture" accept="image/*" capture="environment" style="display:none;">
-            <label for="file-capture" class="upload-btn logo-btn"><img src="assets/logo acceuil.png" alt="Prendre une photo"><span>Prendre une photo</span></label>
+            <label for="file-capture" class="upload-btn logo-btn camera-logo-btn"><img src="assets/logo acceuil.png" alt="Prendre une photo"></label>
 
             <input type="file" id="multi-file-input" accept="image/*" multiple style="display:none;">
-            <label for="multi-file-input" class="upload-btn logo-btn"><img src="assets/logo gallerie.png" alt="Choisir image(s)"></label>
+            <label for="multi-file-input" class="upload-btn logo-btn gallery-logo-btn"><img src="assets/logo gallerie.png" alt="Choisir image(s)"></label>
 
             <div class="search-inline">
                 <input type="search" id="name-search-input" placeholder="Nom d'espèce ou de genre" list="species-suggestions">


### PR DESCRIPTION
## Summary
- reduce camera logo and gallery logo sizes on the home page
- remove caption under the camera logo
- align the gallery logo left

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847c210d918832c9a372c6a576b5e49