### PR TITLE
Add toggleable photo preview

### DIFF
--- a/app.js
+++ b/app.js
@@ -408,6 +408,13 @@ async function identifySingleImage(fileBlob, organ) {
   const results = await callPlantNetAPI(fd);
   if (results) {
     document.body.classList.remove("home");
+    const preview = document.getElementById("preview");
+    if (preview) {
+      preview.classList.add('thumbnail');
+      preview.addEventListener('click', () => {
+        preview.classList.toggle('enlarged');
+      });
+    }
     buildTable(results);
     buildCards(results);
     const latin = results[0]?.species?.scientificNameWithoutAuthor;
@@ -650,7 +657,12 @@ const organBoxOnPage = document.getElementById("organ-choice");
 if (organBoxOnPage) {
   const displayResults = async (results, isNameSearch = false) => {
     const previewEl = document.getElementById("preview");
-    if (previewEl) previewEl.style.display = 'none';
+    if (previewEl) {
+      previewEl.classList.add('thumbnail');
+      previewEl.addEventListener('click', () => {
+        previewEl.classList.toggle('enlarged');
+      });
+    }
     organBoxOnPage.style.display = 'none';
     await ready;
     document.body.classList.remove("home");

--- a/organ.html
+++ b/organ.html
@@ -19,6 +19,8 @@
     body{background:var(--bg);color:var(--text);font-family:system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;margin:0;padding:1.2rem;}
     h1{margin:0 0 1rem;font-size:1.6rem;color:var(--primary)}
     #preview{max-width:100%;height:auto;display:block;margin:0 auto 1rem;}
+    #preview.thumbnail{max-width:150px;cursor:pointer;}
+    #preview.enlarged{max-width:90vw;}
     #organ-choice{text-align:center;margin:1rem 0;}
     #organ-choice button{margin:.25rem;padding:.4rem .8rem;border:1px solid var(--primary);background:var(--primary);color:#fff;border-radius:4px;cursor:pointer;}
     


### PR DESCRIPTION
## Summary
- show small preview image when displaying identification results
- allow clicking the preview to enlarge/shrink

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684833f0c288832c8903fad44379e265