### PR TITLE
Add text labels to organ selection

### DIFF
--- a/organ.html
+++ b/organ.html
@@ -22,7 +22,9 @@
     #preview.thumbnail{max-width:150px;cursor:pointer;}
     #preview.enlarged{max-width:90vw;}
     #organ-choice{text-align:center;margin:1rem 0;}
-    #organ-choice button{margin:.25rem;padding:.4rem .8rem;border:1px solid var(--primary);background:var(--primary);color:#fff;border-radius:4px;cursor:pointer;}
+    #organ-choice button{margin:.25rem;padding:.4rem .8rem;border:1px solid var(--primary);background:var(--primary);color:#fff;border-radius:4px;cursor:pointer;display:flex;flex-direction:column;align-items:center;font-size:1rem;}
+    #organ-choice button .emoji{font-size:3rem;line-height:1;}
+    #organ-choice button .label{margin-top:.25rem;}
     
     .table-wrapper{overflow-x:auto;-webkit-overflow-scrolling:touch;}
     #results{overflow-x:auto;-webkit-overflow-scrolling:touch;}
@@ -88,10 +90,10 @@
   <img id="preview" alt="Prévisualisation">
   <div id="organ-choice">
     <p>Quelle partie de la plante est photographiée&nbsp;?</p>
-    <button type="button" data-organ="flower" aria-label="Fleur">🌸</button>
-    <button type="button" data-organ="leaf" aria-label="Feuille">🍃</button>
-    <button type="button" data-organ="bark" aria-label="Écorce">🪵</button>
-    <button type="button" data-organ="fruit" aria-label="Fruit">🍒</button>
+    <button type="button" data-organ="flower" aria-label="Fleur"><span class="emoji">🌸</span><span class="label">Fleurs</span></button>
+    <button type="button" data-organ="leaf" aria-label="Feuille"><span class="emoji">🍃</span><span class="label">Feuilles</span></button>
+    <button type="button" data-organ="bark" aria-label="Écorce"><span class="emoji">🪵</span><span class="label">Écorce</span></button>
+    <button type="button" data-organ="fruit" aria-label="Fruit"><span class="emoji">🍒</span><span class="label">Fruits</span></button>
   </div>
   <div id="results"></div>
   <div id="info-panel" class="info-panel"></div>


### PR DESCRIPTION
## Summary
- add text labels to organ choice buttons
- increase emoji size for better visibility

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848368fbfc0832c80997f9457a2d4ea