### PR TITLE
Fix mobile layout centering camera icon

### DIFF
--- a/index.html
+++ b/index.html
@@ -79,6 +79,7 @@
     #results::after{content:"";display:block;height:6rem;}
     @media (max-width:600px){
       #results::after{height:50vh;}
+      body.home #main-content{padding-top:15vh;}
     }
     th,td{ padding: 8px 6px; border-bottom:1px solid var(--border); word-wrap: break-word; vertical-align: top; }
     th{background:#fff;color:#000;font-weight:600;text-align:left}


### PR DESCRIPTION
## Summary
- push the main content down on small screens so the camera logo sits near the center

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6849de1e5530832ca3a073846bd9535b