### PR TITLE
Add dedicated OpenObs map page

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -48,10 +48,11 @@ describe('utility functions', () => {
     expect(name).toBe('My_Photo 2024-01-02 03h04.jpg');
   });
 
-  test('openObsMulti builds OR query', () => {
+  test('openObsMulti builds OR query and embeds map', () => {
     const ctx = loadApp();
     const url = ctx.openObsMulti(['1','2']);
     expect(url).toContain(encodeURIComponent('(lsid:1 OR lsid:2)'));
+    expect(url).toContain('embed=true');
   });
 });
 

--- a/app.js
+++ b/app.js
@@ -81,11 +81,11 @@ const slug = n => norm(n).replace(/ /g, "-");
 const infoFlora  = n => `https://www.infoflora.ch/fr/flore/${slug(n)}.html`;
 const inpnStatut = c => `https://inpn.mnhn.fr/espece/cd_nom/${c}/tab/statut`;
 const aura       = c => `https://atlas.biodiversite-auvergne-rhone-alpes.fr/espece/${c}`;
-const openObs    = c => `https://openobs.mnhn.fr/openobs-hub/occurrences/search?q=lsid%3A${c}%20AND%20(dynamicProperties_diffusionGP%3A%22true%22)&qc=&radius=120.6&lat=45.188529&lon=5.724524#tab_mapView`;
+const openObs    = c => `https://openobs.mnhn.fr/openobs-hub/occurrences/search?q=lsid%3A${c}%20AND%20(dynamicProperties_diffusionGP%3A%22true%22)&qc=&radius=120.6&lat=45.188529&lon=5.724524&embed=true#tab_mapView`;
 function openObsMulti(codes) {
   if (!Array.isArray(codes) || codes.length === 0) return '';
   const q = `(${codes.map(c => `lsid:${c}`).join(' OR ')}) AND (dynamicProperties_diffusionGP:"true")`;
-  return `https://openobs.mnhn.fr/openobs-hub/occurrences/search?q=${encodeURIComponent(q)}&qc=&radius=120.6&lat=45.188529&lon=5.724524#tab_mapView`;
+  return `https://openobs.mnhn.fr/openobs-hub/occurrences/search?q=${encodeURIComponent(q)}&qc=&radius=120.6&lat=45.188529&lon=5.724524&embed=true#tab_mapView`;
 }
 const pfaf       = n => `https://pfaf.org/user/Plant.aspx?LatinName=${encodeURIComponent(n).replace(/%20/g, '+')}`;
 const isIOS = () => /iPad|iPhone|iPod/.test(navigator.userAgent);
@@ -367,7 +367,7 @@ async function handleComparisonClick() {
     }));
 
     const cdCodes = speciesData.map(s => cdRef(s.species)).filter(Boolean);
-    const mapUrl = cdCodes.length ? openObsMulti(cdCodes) : '';
+    const mapUrl = cdCodes.length ? `openobs-map.html?codes=${cdCodes.join(',')}` : '';
 
     const comparisonText = await getComparisonFromGemini(speciesData);
     const { intro, tableMarkdown } = parseComparisonText(comparisonText);

--- a/openobs-map.html
+++ b/openobs-map.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>Carte OpenObs</title>
+  <style>
+    html,body{margin:0;padding:0;height:100%;}
+    iframe{border:none;width:100%;height:100%;}
+  </style>
+</head>
+<body>
+  <iframe id="openobs-frame" src=""></iframe>
+  <script src="openobs-map.js"></script>
+</body>
+</html>

--- a/openobs-map.js
+++ b/openobs-map.js
@@ -1,0 +1,14 @@
+function openObsMultiEmbed(codes){
+  if(!Array.isArray(codes) || codes.length===0) return '';
+  const q = `(${codes.map(c=>`lsid:${c}`).join(' OR ')}) AND (dynamicProperties_diffusionGP:"true")`;
+  return `https://openobs.mnhn.fr/openobs-hub/occurrences/search?q=${encodeURIComponent(q)}&qc=&radius=120.6&lat=45.188529&lon=5.724524&embed=true#tab_mapView`;
+}
+
+document.addEventListener('DOMContentLoaded',()=>{
+  const params = new URLSearchParams(location.search);
+  const raw = params.get('codes') || '';
+  const codes = raw.split(',').filter(Boolean);
+  if(codes.length){
+    document.getElementById('openobs-frame').src = openObsMultiEmbed(codes);
+  }
+});

--- a/sw.js
+++ b/sw.js
@@ -3,7 +3,7 @@
    ================================================================ */
 
 // Changez ce nom de version à chaque fois que vous mettez à jour les fichiers de l'application
-const CACHE_NAME = "plantid-v15";
+const CACHE_NAME = "plantid-v16";
 
 // Fichiers essentiels pour le fonctionnement de base de l'application
 const CORE_ASSETS = [
@@ -11,9 +11,11 @@ const CORE_ASSETS = [
   "./index.html",
   "./organ.html",
   "./viewer.html",
+  "./openobs-map.html",
   "./contexte.html",                // NOUVEAU : page contexte environnemental
   "./app.js",
   "./contexte.js",                   // NOUVEAU : script contexte environnemental
+  "./openobs-map.js",
   "./assets/viewer_app.js",
   "./manifest.json",
   "./assets/flora_gallica_toc.json",


### PR DESCRIPTION
## Summary
- provide dedicated page to view OpenObs map
- include new OpenObs embed logic
- show OpenObs map in comparison results via the new page
- cache new assets in service worker
- test openObsMulti for embed parameter

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849df72fe7c832c87055a9b28f797fc