### PR TITLE
Fix iOS fallback PDF link

### DIFF
--- a/assets/viewer_app.js
+++ b/assets/viewer_app.js
@@ -20,8 +20,8 @@ function displayFallback(title, message, pdfUrl, pageNum) {
             <h2>${title}</h2>
             <p>${message}</p>
             <p>Page cible : ${pageNum}</p>
-            <a href="${pdfUrl}" target="_blank" rel="noopener noreferrer">
-                Ouvrir le PDF directement (recherchez la page ${pageNum})
+            <a href="${pdfUrl}#page=${pageNum}" target="_blank" rel="noopener noreferrer">
+                Ouvrir le PDF directement – page ${pageNum}
             </a>
         </div>
     `;


### PR DESCRIPTION
## Summary
- update fallback PDF link so Safari opens at the requested page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684a64970dc4832c92be710f7e730d44