### PR TITLE
Fix iOS PDF fallback link

### DIFF
--- a/assets/viewer_app.js
+++ b/assets/viewer_app.js
@@ -15,9 +15,9 @@ const RENDER_SCALE = isIOS ? 1.8 : 2.0;
  * Affiche un message d'erreur et un lien de secours.
  */
 function displayFallback(title, message, pdfUrl, pageNum) {
-    const altUrl = isIOS
-        ? `viewer.html?file=${encodeURIComponent(pdfUrl)}&page=${pageNum}`
-        : `${pdfUrl}#page=${pageNum}`;
+    // Utilise un lien direct vers le PDF avec ancre de page pour un comportement
+    // cohérent, notamment sur iOS
+    const altUrl = `${encodeURI(pdfUrl)}#page=${pageNum}`;
     viewerContainer.innerHTML = `
         <div class="error-message">
             <h2>${title}</h2>


### PR DESCRIPTION
## Summary
- ensure the PDF fallback link navigates to the requested page by using a direct URL with a `#page` anchor

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684abecaf88c832ca42e48e67bb6b21b