### PR TITLE
Add Gemini similar species suggestion

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,4 +101,7 @@ This launches the Jest test suite which validates the helper utilities and the
 - Clicking a species name copies the Latin name to the clipboard.
 - Google Gemini can generate a comparison table with optional text‑to‑speech
   playback.
+- When a single species is searched, a button under the results can retrieve
+  suggestions of morphologically similar species from the same genus using the
+  Gemini API.
 

--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -95,4 +95,14 @@ describe('api helpers', () => {
     const txt = await ctx.getComparisonFromGemini([{species:'A',physio:'p',eco:'e'}]);
     expect(txt).toBe('cmp');
   });
+
+  test('getSimilarSpeciesFromGemini parses list', async () => {
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({candidates:[{content:{parts:[{text:'Abies grandis, Abies cephalonica'}]}}]})
+    });
+    const ctx = loadApp({ fetch: fetchMock });
+    const list = await ctx.getSimilarSpeciesFromGemini('Abies alba');
+    expect(list).toEqual(['Abies grandis','Abies cephalonica']);
+  });
 });

--- a/app.js
+++ b/app.js
@@ -27,6 +27,8 @@ let criteres = {}; // NOUVEAU : pour les critères physiologiques
 let physionomie = {}; // Nouvelle table pour la physionomie
 let userLocation = { latitude: 45.188529, longitude: 5.724524 };
 
+let displayedItems = [];
+
 let dataPromise = null;
 function loadData() {
   if (dataPromise) return dataPromise;
@@ -272,6 +274,20 @@ function playAudioFromBase64(base64Audio) {
     });
 }
 
+async function getSimilarSpeciesFromGemini(speciesName, limit = 3) {
+    const genus = speciesName.split(/\s+/)[0];
+    const prompt = `Donne une liste de ${limit} espèces du genre ${genus} avec lesquelles ${speciesName} peut être confondu pour des raisons morphologiques. Réponds uniquement par une liste séparée par des virgules.`;
+    const requestBody = {
+        contents: [{ parts: [{ text: prompt }] }],
+        generationConfig: { temperature: 0.4, maxOutputTokens: 60 }
+    };
+    const data = await apiFetch(GEMINI_ENDPOINT, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(requestBody) });
+    if (!data) return [];
+    const txt = data.candidates && data.candidates[0] && data.candidates[0].content && data.candidates[0].content.parts && data.candidates[0].content.parts[0] && data.candidates[0].content.parts[0].text;
+    if (!txt) return [];
+    return txt.split(/[,\n;]/).map(s => s.trim()).filter(Boolean);
+}
+
 
 window.handleSynthesisClick = async function(event, element, speciesName) {
     event.preventDefault();
@@ -477,8 +493,9 @@ async function identifySingleImage(fileBlob, organ) {
         preview.classList.toggle('enlarged');
       });
     }
-    buildTable(results);
-    buildCards(results);
+    displayedItems = results;
+    buildTable(displayedItems);
+    buildCards(displayedItems);
     const latin = results[0] && results[0].species
       ? results[0].species.scientificNameWithoutAuthor
       : undefined;
@@ -523,11 +540,12 @@ function buildTable(items){
         floreAlpesLink = linkIcon(`https://www.florealpes.com/${urlPart}`, "FloreAlpes.png", "FloreAlpes");
     }
     const escapedSci = displaySci.replace(/'/g, "\\'");
+    const checkedAttr = item.autoCheck ? ' checked' : '';
     return `<tr>
               <td class="col-checkbox">
-                <input type="checkbox" class="species-checkbox" 
-                       data-species="${escapedSci}" 
-                       data-physio="${encodeURIComponent(phys)}" 
+                <input type="checkbox" class="species-checkbox"${checkedAttr}
+                       data-species="${escapedSci}"
+                       data-physio="${encodeURIComponent(phys)}"
                        data-eco="${encodeURIComponent(eco)}">
               </td>
               <td class="col-nom-latin" data-latin="${displaySci}">${displaySci}<br><span class="score">(${pct})</span></td>
@@ -564,19 +582,25 @@ function buildTable(items){
       compareBtn.className = 'action-button';
       compareBtn.style.display = 'none';
       compareBtn.style.padding = '0.8rem 1.5rem';
-      
+
       footer.appendChild(compareBtn);
 
       compareBtn.addEventListener('click', handleComparisonClick);
   }
 
+  const updateCompareVisibility = () => {
+      const checkedCount = wrap.querySelectorAll('.species-checkbox:checked').length;
+      const compareBtn = document.getElementById('compare-btn');
+      if(compareBtn) {
+        compareBtn.style.display = (checkedCount >= 2) ? 'inline-block' : 'none';
+      }
+  };
+
+  updateCompareVisibility();
+
   wrap.addEventListener('change', (e) => {
       if (e.target.classList.contains('species-checkbox')) {
-          const checkedCount = wrap.querySelectorAll('.species-checkbox:checked').length;
-          const compareBtn = document.getElementById('compare-btn');
-          if(compareBtn) {
-            compareBtn.style.display = (checkedCount >= 2) ? 'inline-block' : 'none';
-          }
+          updateCompareVisibility();
       }
   });
 
@@ -646,6 +670,34 @@ function buildCards(items){
     }
     details.innerHTML = `<summary>${displaySci} — ${pct}${!isNameSearchResult ? '%' : ''}</summary><p style="padding:0 12px 8px;font-style:italic">${ecolOf(sci)}</p>${iframeHTML}`;
     zone.appendChild(details);
+  });
+}
+
+function showSimilarSpeciesButton(speciesName) {
+  const area = document.getElementById('similar-btn-area');
+  if (!area) return;
+  area.innerHTML = '';
+  const btn = document.createElement('button');
+  btn.id = 'similar-btn';
+  btn.textContent = 'Montrer des espèces similaires';
+  btn.className = 'action-button';
+  area.appendChild(btn);
+  btn.addEventListener('click', async () => {
+    btn.disabled = true;
+    btn.textContent = 'Recherche...';
+    const extras = await getSimilarSpeciesFromGemini(speciesName);
+    btn.remove();
+    if (extras.length) {
+      extras.forEach(n => {
+        if (!displayedItems.some(it => it.species.scientificNameWithoutAuthor === n)) {
+          displayedItems.push({ score: 0, species: { scientificNameWithoutAuthor: n }, autoCheck: true });
+        }
+      });
+      buildTable(displayedItems);
+      buildCards(displayedItems);
+    } else {
+      showNotification('Aucune espèce similaire trouvée.', 'error');
+    }
   });
 }
 
@@ -784,11 +836,20 @@ if (organBoxOnPage) {
     organBoxOnPage.style.display = 'none';
     await loadData();
     document.body.classList.remove("home");
-    const items = isNameSearch
-      ? results.map(n => ({ score: 1.0, species: { scientificNameWithoutAuthor: n } }))
+    let items = isNameSearch
+      ? results.map(n => ({ score: 1.0, species: { scientificNameWithoutAuthor: n }, autoCheck: results.length === 1 }))
       : results;
-    buildTable(items);
-    buildCards(items);
+
+    displayedItems = items;
+    buildTable(displayedItems);
+    buildCards(displayedItems);
+
+    if (isNameSearch && results.length === 1) {
+      showSimilarSpeciesButton(results[0]);
+    } else {
+      const area = document.getElementById('similar-btn-area');
+      if (area) area.innerHTML = '';
+    }
   };
 
   const namesRaw = sessionStorage.getItem("speciesQueryNames");

--- a/index.html
+++ b/index.html
@@ -151,6 +151,7 @@
             <button type="button" id="multi-image-identify-button" class="action-button" style="display: none;">Identifier</button>
         </div>
         <div id="results"></div>
+        <div id="similar-btn-area"></div>
     </div>
 
     <div id="synthesis-modal" class="synthesis-modal-overlay">

--- a/organ.html
+++ b/organ.html
@@ -97,6 +97,7 @@
     <button type="button" data-organ="bark" aria-label="Écorce"><span class="emoji">🪵</span><span class="label">Écorce</span></button>
   </div>
   <div id="results"></div>
+  <div id="similar-btn-area"></div>
   <div id="info-panel" class="info-panel"></div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- support fetching similar species suggestions
- automatically show a button when a single name search matches
- track displayed items and refresh with Gemini results
- add README note about similar species workflow
- test parsing Gemini list output

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684ad688054c832c98ecf2d540f4aa67