### PR TITLE
Add embedded map for comparison

### DIFF
--- a/app.js
+++ b/app.js
@@ -88,11 +88,11 @@ function capitalizeGenus(name) {
 const infoFlora  = n => `https://www.infoflora.ch/fr/flore/${slug(n)}.html`;
 const inpnStatut = c => `https://inpn.mnhn.fr/espece/cd_nom/${c}/tab/statut`;
 const aura       = c => `https://atlas.biodiversite-auvergne-rhone-alpes.fr/espece/${c}`;
-const openObs    = c => `https://openobs.mnhn.fr/openobs-hub/occurrences/search?q=lsid%3A${c}%20AND%20(dynamicProperties_diffusionGP%3A%22true%22)&qc=&radius=120.6&lat=45.188529&lon=5.724524#tab_mapView`;
+const openObs    = c => `https://openobs.mnhn.fr/openobs-hub/occurrences/search?q=lsid%3A${c}%20AND%20(dynamicProperties_diffusionGP%3A%22true%22)&qc=&radius=120.6&lat=45.188529&lon=5.724524&embed=true#tab_mapView`;
 function openObsMulti(codes) {
   if (!Array.isArray(codes) || codes.length === 0) return '';
   const q = `(${codes.map(c => `lsid:${c}`).join(' OR ')}) AND (dynamicProperties_diffusionGP:"true")`;
-  return `https://openobs.mnhn.fr/openobs-hub/occurrences/search?q=${encodeURIComponent(q)}&qc=&radius=120.6&lat=45.188529&lon=5.724524#tab_mapView`;
+  return `https://openobs.mnhn.fr/openobs-hub/occurrences/search?q=${encodeURIComponent(q)}&qc=&radius=120.6&lat=45.188529&lon=5.724524&embed=true#tab_mapView`;
 }
 const pfaf       = n => `https://pfaf.org/user/Plant.aspx?LatinName=${encodeURIComponent(n).replace(/%20/g, '+')}`;
 const isIOS = () => /iPad|iPhone|iPod/.test(navigator.userAgent);
@@ -464,7 +464,9 @@ async function handleComparisonClick() {
         </div>
         <hr style="border: none; border-top: 1px solid var(--border, #e0e0e0); margin: 1rem 0;">
         <div id="comparison-text-content"><p>${intro}</p>${tableHtml}</div>
-        ${mapUrl ? `<div style="margin-top:1.5rem;"><iframe loading="lazy" src="${mapUrl}" title="Carte OpenObs" style="width:100%;height:400px;border:none;"></iframe></div>` : ''}
+        ${mapUrl ? `<div style="margin:1.5rem calc(50% - 50vw);">
+            <iframe loading="lazy" src="${mapUrl}" title="Carte OpenObs" style="width:100vw;height:80vh;border:none;"></iframe>
+        </div>` : ''}
     `;
 
     // Ajout de l'écouteur d'événement pour le nouveau bouton de synthèse vocale.


### PR DESCRIPTION
## Summary
- display the OpenObs map directly at full page width when comparing species
- update OpenObs URL helpers to use the embed view

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684bab347c60832c986be8fbdafc95ec