### PR TITLE
Add search bar on results screen

### DIFF
--- a/app.js
+++ b/app.js
@@ -757,6 +757,63 @@ const nameSearchInput = document.getElementById("name-search-input");
 const nameSearchButton = document.getElementById("name-search-button");
 const speciesSuggestions = document.getElementById("species-suggestions");
 
+const performNameSearch = async () => {
+  const raw = nameSearchInput.value.trim();
+  if (!raw) return;
+  await loadData();
+  const queries = raw.split(/[;,\n]+/).map(q => q.trim()).filter(Boolean);
+  if (queries.length === 1 && queries[0].split(/\s+/).length === 1) {
+    const q = queries[0];
+    const tocEntry = floraToc[norm(q)];
+    if (tocEntry && tocEntry.pdfFile && tocEntry.page) {
+      sessionStorage.setItem("speciesQueryNames", JSON.stringify([q]));
+      ["photoData", "identificationResults"].forEach(k => sessionStorage.removeItem(k));
+      location.href = "organ.html";
+    } else {
+      showNotification(`Genre "${q}" non trouvé.`, "error");
+    }
+    return;
+  }
+  const found = [];
+  for (const q of queries) {
+    const normQuery = norm(q);
+    let foundName = taxrefNames.find(n => norm(n) === normQuery);
+    if (!foundName) {
+      const triList = trigramIndex[normQuery];
+      if (triList && triList.length === 1) {
+        foundName = triList[0];
+      } else {
+        const partial = taxrefNames.filter(n => {
+          const nk = norm(n);
+          return nk.startsWith(normQuery) || (nameTrigram[n] && nameTrigram[n].startsWith(normQuery));
+        });
+        if (partial.length === 1) foundName = partial[0];
+      }
+      if (!foundName) {
+        const matches = await taxrefFuzzyMatch(q);
+        if (matches.length) {
+          const best = matches[0];
+          foundName = best.nom_complet || best.name || best.nom;
+          const sc = best.score !== undefined ? ` (${Math.round(best.score * 100)}%)` : '';
+          showNotification(`Suggestion : ${foundName}${sc}`, 'success');
+        }
+      }
+    }
+    if (foundName) {
+      found.push(foundName);
+    } else {
+      showNotification(`Espèce "${q}" non trouvée.`, "error");
+    }
+  }
+  if (found.length) {
+    sessionStorage.setItem("speciesQueryNames", JSON.stringify(found));
+    ["photoData", "identificationResults"].forEach(k => sessionStorage.removeItem(k));
+    location.href = "organ.html";
+  }
+};
+if (nameSearchButton) nameSearchButton.addEventListener("click", performNameSearch);
+if (nameSearchInput) nameSearchInput.addEventListener("keypress", e => { if (e.key === "Enter") performNameSearch(); });
+
 if (document.getElementById("file-capture")) {
   const fileCaptureInput = document.getElementById("file-capture");
   const multiFileInput = document.getElementById("multi-file-input");
@@ -770,62 +827,6 @@ if (document.getElementById("file-capture")) {
       if (f) handleSingleFileSelect(f);
     });
   }
-  const performNameSearch = async () => {
-    const raw = nameSearchInput.value.trim();
-    if (!raw) return;
-    await loadData();
-    const queries = raw.split(/[;,\n]+/).map(q => q.trim()).filter(Boolean);
-    if (queries.length === 1 && queries[0].split(/\s+/).length === 1) {
-      const q = queries[0];
-      const tocEntry = floraToc[norm(q)];
-      if (tocEntry && tocEntry.pdfFile && tocEntry.page) {
-        sessionStorage.setItem("speciesQueryNames", JSON.stringify([q]));
-        ["photoData", "identificationResults"].forEach(k => sessionStorage.removeItem(k));
-        location.href = "organ.html";
-      } else {
-        showNotification(`Genre "${q}" non trouvé.`, "error");
-      }
-      return;
-    }
-    const found = [];
-    for (const q of queries) {
-      const normQuery = norm(q);
-      let foundName = taxrefNames.find(n => norm(n) === normQuery);
-      if (!foundName) {
-        const triList = trigramIndex[normQuery];
-        if (triList && triList.length === 1) {
-          foundName = triList[0];
-        } else {
-          const partial = taxrefNames.filter(n => {
-            const nk = norm(n);
-            return nk.startsWith(normQuery) || (nameTrigram[n] && nameTrigram[n].startsWith(normQuery));
-          });
-          if (partial.length === 1) foundName = partial[0];
-        }
-        if (!foundName) {
-          const matches = await taxrefFuzzyMatch(q);
-          if (matches.length) {
-            const best = matches[0];
-            foundName = best.nom_complet || best.name || best.nom;
-            const sc = best.score !== undefined ? ` (${Math.round(best.score * 100)}%)` : '';
-            showNotification(`Suggestion : ${foundName}${sc}`, 'success');
-          }
-        }
-      }
-      if (foundName) {
-        found.push(foundName);
-      } else {
-        showNotification(`Espèce "${q}" non trouvée.`, "error");
-      }
-    }
-    if (found.length) {
-      sessionStorage.setItem("speciesQueryNames", JSON.stringify(found));
-      ["photoData", "identificationResults"].forEach(k => sessionStorage.removeItem(k));
-      location.href = "organ.html";
-    }
-  };
-  if (nameSearchButton) nameSearchButton.addEventListener("click", performNameSearch);
-  if (nameSearchInput) nameSearchInput.addEventListener("keypress", e => { if (e.key === "Enter") performNameSearch(); });
   function renderMultiImageList() {
     multiImageListArea.innerHTML = '';
     multiImageIdentifyButton.style.display = selectedMultiFilesData.length > 0 ? 'block' : 'none';

--- a/organ.html
+++ b/organ.html
@@ -68,6 +68,9 @@
     }
     img.small-logo { height: 24px; width: auto; }
 
+    .search-inline{display:flex;gap:.5rem;align-items:center;}
+    .search-inline input[type="search"]{flex-grow:1;padding:10px;border:1px solid var(--border);border-radius:6px;font-size:1rem;margin:0;background-color:#fff;}
+    
     .info-panel{display:none;padding:1rem;background:var(--card);border:1px solid var(--border);border-radius:6px;margin-top:1rem;}
 
     #similar-btn-area { text-align: center; margin-top: 0; }
@@ -101,11 +104,16 @@
     #theme-toggle:hover{transform:scale(1.1);}
   </style>
 </head>
-<body class="home">
-  <div style="display:flex;justify-content:space-between;align-items:center;">
-    <h1 style="margin:0">Plante App</h1>
-    <button id="theme-toggle" title="Basculer le thème">🌙</button>
-  </div>
+  <body class="home">
+    <div style="display:flex;justify-content:space-between;align-items:center;gap:1rem;">
+      <h1 style="margin:0">Plante App</h1>
+      <div class="search-inline" style="max-width:450px;flex-grow:1;">
+        <input type="search" id="name-search-input" placeholder="Nom d'espèce ou de genre" list="species-suggestions">
+        <datalist id="species-suggestions"></datalist>
+        <button type="button" id="name-search-button" class="action-button">Rechercher</button>
+      </div>
+      <button id="theme-toggle" title="Basculer le thème">🌙</button>
+    </div>
   <img id="preview" alt="Prévisualisation">
   <div id="organ-choice">
     <p>Quelle partie de la plante est photographiée&nbsp;?</p>


### PR DESCRIPTION
## Summary
- keep species search box available on the results page
- reuse the existing search logic on any page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684bcd71da94832ca67086be00fb3b79