### PR TITLE
Add PCA Habitat page per plan step 1

### DIFF
--- a/index.html
+++ b/index.html
@@ -143,7 +143,7 @@
             <button class="tab active">Identification</button>
             <button class="tab" onclick="window.location.href='contexte.html'">Contexte environnemental</button>
             <button class="tab" onclick="window.location.href='sheets.html'">Google Sheets</button>
-            <button class="tab" onclick="window.location.href='pca.html'">Analyse d'Habitat (ACP)</button>
+            <button class="tab" onclick="window.location.href='pca.html'">PCA Habitat</button>
         </div>
         <button id="theme-toggle" title="Basculer le thème">🌙</button>
     </nav>

--- a/pca.html
+++ b/pca.html
@@ -23,6 +23,10 @@
     #theme-toggle{ background:none; border:none; cursor:pointer; font-size:1.2rem; color:var(--text); padding:0 1rem; }
     #theme-toggle:hover{ transform:scale(1.1); }
     .main-content{ flex:1; padding:1.5rem; max-width:900px; width:100%; margin:0 auto; text-align:center; }
+    form#pca-form { display:flex; flex-direction:column; gap:1rem; align-items:center; margin-top:1rem; }
+    form#pca-form label { font-weight:600; }
+    form#pca-form input[type="file"] { margin-top:0.3rem; }
+    form#pca-form button { padding:0.6rem 1.2rem; background:var(--primary); color:#fff; border:none; border-radius:4px; cursor:pointer; }
   </style>
 </head>
 <body>
@@ -37,15 +41,18 @@
   </nav>
 
   <div class="main-content">
-    <h1>Analyse d'Habitat (ACP)</h1>
-    <p>Sélectionnez une ou plusieurs espèces puis lancez l'analyse.</p>
-    <select id="species-select" multiple style="min-width:250px; max-width:100%;"></select>
-    <div style="margin-top:1rem;">
-      <button id="run-pca-button" class="action-button">Lancer l'analyse</button>
-    </div>
-    <div id="pca-correlation-circle-plot" style="margin-top:2rem;"></div>
-    <div id="pca-individuals-plot" style="margin-top:2rem;"></div>
-    <div id="pca-results-table" style="margin-top:2rem;"></div>
+    <h1>Analyse en Composantes Principales (ACP) sur les Habitats</h1>
+    <form id="pca-form">
+      <label for="user_file">Relevés à analyser (CSV):</label>
+      <input type="file" id="user_file" name="user_file" accept=".csv">
+
+      <label for="ref_file">Référence phytosociologique (CSV):</label>
+      <input type="file" id="ref_file" name="ref_file" accept=".csv">
+
+      <button type="submit">Lancer l'Analyse</button>
+    </form>
+    <div id="pca-plot-container"></div>
+    <div id="cooccurrence-table-container"></div>
   </div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add `PCA Habitat` link to main navigation
- create basic `pca.html` page with upload form and result containers

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684c0ffcb8d0832c95864d2bb81f4a2c