### PR TITLE
Fix Google Sheet URL validation

### DIFF
--- a/sheets.html
+++ b/sheets.html
@@ -56,7 +56,7 @@
         <br>
         2. Sous l'onglet "Lien", choisissez la feuille à publier et sélectionnez le format "<strong>Valeurs séparées par des virgules (.csv)</strong>".
         <br>
-        3. Cliquez sur "Publier" et copiez l'URL générée. Elle doit se terminer par <strong>`.../pub?output=csv`</strong>.
+        3. Cliquez sur "Publier" et copiez l'URL générée. Elle contient généralement <strong>`/pub`</strong> suivi du paramètre <strong>`output=csv`</strong>.
     </p>
     <div class="sheet-input">
       <input type="text" id="sheet-csv-url" placeholder="Collez l'URL de publication .csv de la feuille">

--- a/ui.js
+++ b/ui.js
@@ -103,9 +103,11 @@
             return;
         }
 
-        // Validation plus stricte de l'URL
-        if (!url.includes('/pub?output=csv')) {
-            const errorMsg = "URL invalide. Assurez-vous d'utiliser l'URL de publication se terminant par '.../pub?output=csv'.";
+        // Validation plus souple de l'URL
+        // On accepte les liens de publication du type `/pub?...output=csv` qui
+        // peuvent contenir d'autres paramètres (gid, single, etc.).
+        if (!(url.includes('/pub') && url.includes('output=csv'))) {
+            const errorMsg = "URL invalide. Assurez-vous d'utiliser l'URL de publication contenant '/pub' et le paramètre 'output=csv'.";
             window.showNotification(errorMsg, 'error');
             container.innerHTML = `<p style="color:red;">${errorMsg}</p>`;
             window.toggleSpinner(false);


### PR DESCRIPTION
## Summary
- relax URL check for Google Sheet CSV
- clarify instructions for publishing the CSV

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c2eebacf8832c87f44a184375a3f5