### PR TITLE
Add full-screen overlay for environmental context map

### DIFF
--- a/contexte.html
+++ b/contexte.html
@@ -37,10 +37,14 @@
     .action-button { padding: 12px 20px; background: var(--primary); color: white; border: none; border-radius: 6px; font-size: 1rem; cursor: pointer; transition: all 0.3s; width: 100%; }
     .action-button:hover { background: #2e7d32; transform: scale(1.02); }
     .action-button:disabled { background: #ccc; cursor: not-allowed; transform: none; }
-    
+
     /* Carte interactive */
     #map-container { display: none; margin-top: 1rem; border-radius: 8px; overflow: hidden; box-shadow: 0 2px 6px rgba(0,0,0,0.1); }
     #map { height: 400px; width: 100%; }
+
+    .env-map-overlay { position: fixed; top:0; left:0; width:100%; height:100%; background: var(--bg); z-index:2000; display:none; flex-direction:column; }
+    .env-map-close { position: absolute; top:10px; left:10px; font-size:2rem; background:none; border:none; color:var(--text); cursor:pointer; z-index:2100; }
+    #env-map { width:100%; height:100%; }
     
     /* Coordonnées sélectionnées */
     .coordinates-display { display: none; margin-top: 1rem; padding: 1rem; background: rgba(56, 142, 60, 0.1); border-radius: 6px; text-align: center; }
@@ -140,10 +144,14 @@
       <div class="results-grid" id="results-grid">
         <!-- Les cartes de résultats seront ajoutées ici dynamiquement -->
       </div>
-      <!-- Nouvelle carte avec couches WMS -->
-      <h2 style="margin-top:2rem;">Carte interactive</h2>
-      <div id="layer-controls" style="margin-bottom:0.5rem;"></div>
-      <div id="env-map" style="height:800px;width:100%;display:none;"></div>
+      <button class="action-button" id="open-env-map" style="margin-top:1rem;">
+        Contexte écologique - Zonage
+      </button>
+    </div>
+    <div id="env-map-overlay" class="env-map-overlay" style="display:none;">
+      <button id="env-map-close" class="env-map-close" title="Fermer">&times;</button>
+      <div id="layer-controls" style="margin:0 0 0.5rem 0;"></div>
+      <div id="env-map" style="flex:1;"></div>
     </div>
   </div>
 </body>

--- a/contexte.js
+++ b/contexte.js
@@ -122,13 +122,19 @@ function latLonToWebMercator(lat, lon) {
 
 // Initialisation au chargement de la page
 document.addEventListener('DOMContentLoaded', () => {
-	document.getElementById('use-geolocation').addEventListener('click', useGeolocation);
-	document.getElementById('choose-on-map').addEventListener('click', toggleMap);
-	document.getElementById('validate-location').addEventListener('click', validateLocation);
-	document.getElementById('search-address').addEventListener('click', searchAddress);
-	document.getElementById('address-input').addEventListener('keydown', (e) => {
-		if (e.key === 'Enter') searchAddress();
-	});
+        document.getElementById('use-geolocation').addEventListener('click', useGeolocation);
+        document.getElementById('choose-on-map').addEventListener('click', toggleMap);
+        document.getElementById('validate-location').addEventListener('click', validateLocation);
+        document.getElementById('search-address').addEventListener('click', searchAddress);
+        document.getElementById('address-input').addEventListener('keydown', (e) => {
+                if (e.key === 'Enter') searchAddress();
+        });
+        const openBtn = document.getElementById('open-env-map');
+        const closeBtn = document.getElementById('env-map-close');
+        if (openBtn && closeBtn) {
+                openBtn.addEventListener('click', openEnvMap);
+                closeBtn.addEventListener('click', closeEnvMap);
+        }
 });
 
 // Fonction pour utiliser la géolocalisation
@@ -307,8 +313,7 @@ function showResults() {
 			resultsGrid.appendChild(card);
 		});
 
-		displayInteractiveEnvMap();
-		resultsSection.scrollIntoView({ behavior: 'smooth', block: 'start' });
+                resultsSection.scrollIntoView({ behavior: 'smooth', block: 'start' });
 	}, 500);
 }
 
@@ -318,15 +323,14 @@ function showResults() {
  */
 async function displayInteractiveEnvMap() {
     const mapDiv = document.getElementById('env-map');
-    mapDiv.style.display = 'block';
-    document.getElementById('layer-controls').style.display = 'none'; // On n'utilise plus les contrôles manuels
+    document.getElementById('layer-controls').style.display = 'none';
 
     // Initialisation ou réinitialisation de la carte
     if (!envMap) {
         envMap = L.map('env-map').setView([selectedLat, selectedLon], 11);
-        L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-            attribution: '© OpenStreetMap contributors',
-            maxZoom: 19
+        L.tileLayer('https://{s}.tile.opentopomap.org/{z}/{x}/{y}.png', {
+            attribution: '© OpenStreetMap contributors, SRTM | Map style: © OpenTopoMap (CC-BY-SA)',
+            maxZoom: 17
         }).addTo(envMap);
     } else {
         envMap.setView([selectedLat, selectedLon], 11);
@@ -433,6 +437,30 @@ function addDynamicPopup(feature, layer) {
         }
     });
 }
+
+function openEnvMap() {
+    displayInteractiveEnvMap();
+    const overlay = document.getElementById('env-map-overlay');
+    if (overlay) {
+        overlay.style.display = 'flex';
+        history.pushState({envMap:true}, '');
+    }
+}
+
+function closeEnvMap() {
+    const overlay = document.getElementById('env-map-overlay');
+    if (overlay) {
+        overlay.style.display = 'none';
+        if (history.state && history.state.envMap) history.back();
+    }
+}
+
+window.addEventListener('popstate', () => {
+    const overlay = document.getElementById('env-map-overlay');
+    if (overlay && overlay.style.display === 'flex') {
+        overlay.style.display = 'none';
+    }
+});
 
 // Fonction de notification générique
 function showNotification(message, type = 'info') {


### PR DESCRIPTION
## Summary
- replace embedded env map with open button
- show map in fullscreen overlay with close button
- load map using OpenTopoMap tiles
- allow closing overlay via back button

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684d01fd2400832cbaa7daede2c7329a