### PR TITLE
Add Google Maps long press on context map

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,4 +127,7 @@ Follow the official Cloud Run documentation for detailed steps.
   retrieved from the IGN API Carto. It now includes layers for **Réserves
   Naturelles Nationales et Régionales**, **Arrêtés Préfectoraux de Protection de
   Biotope**, **Espaces Naturels Sensibles** and **Zones humides**.
+- A long press (about two seconds) on the environmental context map opens a
+  pop‑up with a **Google Maps** link to the selected coordinates. The timer is
+  cancelled if the user starts moving the map.
 

--- a/contexte.js
+++ b/contexte.js
@@ -12,6 +12,8 @@ let marker = null;
 let selectedLat = null;
 let selectedLon = null;
 
+const GOOGLE_MAPS_LONG_PRESS_MS = 2000;
+
 // Configuration des services externes (liens)
 const SERVICES = {
 	arcgis: {
@@ -294,8 +296,41 @@ function showResults() {
 		});
 
 		displayInteractiveEnvMap();
-		resultsSection.scrollIntoView({ behavior: 'smooth', block: 'start' });
-	}, 500);
+        resultsSection.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    }, 500);
+}
+
+/**
+ * Active un appui long pour ouvrir Google Maps sur la carte fournie.
+ * @param {L.Map} targetMap
+ */
+function enableGoogleMapsLongPress(targetMap) {
+    let timer;
+    let startEvent;
+
+    function start(e) {
+        startEvent = e;
+        timer = setTimeout(() => {
+            const lat = startEvent.latlng.lat.toFixed(6);
+            const lon = startEvent.latlng.lng.toFixed(6);
+            L.popup()
+                .setLatLng(startEvent.latlng)
+                .setContent(`<a href="https://www.google.com/maps?q=${lat},${lon}" target="_blank" rel="noopener noreferrer">Google Maps</a>`)
+                .openOn(targetMap);
+        }, GOOGLE_MAPS_LONG_PRESS_MS);
+    }
+
+    function cancel() {
+        clearTimeout(timer);
+    }
+
+    targetMap.on('mousedown', start);
+    targetMap.on('touchstart', start);
+    targetMap.on('mouseup', cancel);
+    targetMap.on('touchend', cancel);
+    targetMap.on('dragstart', cancel);
+    targetMap.on('move', cancel);
+    targetMap.on('zoomstart', cancel);
 }
 
 /**
@@ -314,6 +349,7 @@ async function displayInteractiveEnvMap() {
             attribution: '© OpenStreetMap contributors, SRTM | Map style: © OpenTopoMap (CC-BY-SA)',
             maxZoom: 17
         }).addTo(envMap);
+        enableGoogleMapsLongPress(envMap);
     } else {
         envMap.setView([selectedLat, selectedLon], 11);
         if (layerControl) envMap.removeControl(layerControl); // Supprime l'ancien contrôle de couches


### PR DESCRIPTION
## Summary
- introduce `GOOGLE_MAPS_LONG_PRESS_MS` constant
- add `enableGoogleMapsLongPress` utility and hook it into env map initialization
- document long press Google Maps feature in README

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684ed892ff98832caf036f1583d6e3c8