### PR TITLE
Add Google Maps long press on context map

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,4 +127,7 @@ Follow the official Cloud Run documentation for detailed steps.
   retrieved from the IGN API Carto. It now includes layers for **Réserves
   Naturelles Nationales et Régionales**, **Arrêtés Préfectoraux de Protection de
   Biotope**, **Espaces Naturels Sensibles** and **Zones humides**.
+- A long press (about two seconds) on the environmental context map opens a
+  pop‑up with a **Google Maps** link to the selected coordinates. The timer is
+  cancelled if the user starts moving the map.
 


### PR DESCRIPTION
## Summary
- introduce `GOOGLE_MAPS_LONG_PRESS_MS` constant
- add `enableGoogleMapsLongPress` utility and hook it into env map initialization
- document long press Google Maps feature in README
- refine long-press logic to cancel on pointer move events

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_684ed892ff98832caf036f1583d6e3c8