### PR TITLE
Compact blue layout for environmental context page

### DIFF
--- a/contexte.html
+++ b/contexte.html
@@ -12,7 +12,8 @@
   <script defer src="contexte.js"></script>
   <script defer src="sw-register.js"></script>
   <style>
-    :root{ --primary:#388e3c; --bg:#f6f9fb; --card:#ffffff; --border:#e0e0e0; --text:#202124; --max-width:600px; }
+    /* Primary color changed to blue for a compact look */
+    :root{ --primary:#0d6efd; --bg:#f6f9fb; --card:#ffffff; --border:#e0e0e0; --text:#202124; --max-width:600px; }
     html[data-theme="dark"]{ --bg:#181a1b; --card:#262b2f; --border:#333; --text:#ececec; }
     *{box-sizing:border-box;}
     body{ background:var(--bg); color:var(--text); font-family:system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif; margin:0; padding:0; display:flex; flex-direction:column; min-height:100vh; }
@@ -21,31 +22,31 @@
     .tabs-container { background: var(--card); box-shadow: 0 2px 4px rgba(0,0,0,0.1); position: sticky; top: 0; z-index: 100; display:flex; align-items:center; justify-content:space-between; }
     .tabs { display: flex; border-bottom: 2px solid var(--border); flex-grow:1; }
     .tab { flex: 1; padding: 1rem; text-align: center; cursor: pointer; background: none; border: none; font-size: 1rem; color: var(--text); transition: all 0.3s; position: relative; }
-    .tab:hover { background: rgba(56, 142, 60, 0.1); }
+    .tab:hover { background: rgba(13, 110, 253, 0.1); }
     .tab.active { color: var(--primary); font-weight: 600; }
     .tab.active::after { content: ''; position: absolute; bottom: -2px; left: 0; right: 0; height: 2px; background: var(--primary); }
     
     /* Contenu principal */
-    .main-content { flex: 1; padding: 1rem; max-width: var(--max-width); margin: 0 auto; width: 100%; display:flex; flex-direction:column; gap:1rem; }
+    .main-content { flex: 1; padding: 1rem; max-width: var(--max-width); margin: 0 auto; width: 100%; display:flex; flex-direction:column; gap:0.5rem; }
     h1 { color: var(--primary); margin: 0 0 1.5rem; font-size: 1.6rem; text-align: center; }
     
     /* Options de localisation */
-    .location-options { display: flex; flex-direction: column; gap: 1rem; margin-bottom: 1rem; }
-    .location-card { background: var(--card); border-radius: 8px; padding: 0.8rem 1rem; box-shadow: 0 2px 6px rgba(0,0,0,0.1); }
-    .location-card h2 { font-size: 1.2rem; color: var(--primary); margin: 0 0 1rem; display:flex; align-items:center; }
-    .location-card .icon { font-size: 1.8rem; margin-right: 0.5rem; }
+    .location-options { display: flex; flex-direction: column; gap: 0.5rem; margin-bottom: 0.5rem; }
+    .location-card { background: var(--card); border-radius: 8px; padding: 0.5rem 0.8rem; box-shadow: 0 2px 6px rgba(0,0,0,0.1); }
+    .location-card h2 { display:none; }
+    .location-card .icon { display:none; }
     
-    .action-button { padding: 12px 20px; background: var(--primary); color: white; border: none; border-radius: 6px; font-size: 1rem; cursor: pointer; transition: all 0.3s; width: 100%; }
-    .action-button:hover { background: #2e7d32; transform: scale(1.02); }
+    .action-button { padding: 10px 16px; background: var(--primary); color: white; border: none; border-radius: 6px; font-size: 1rem; cursor: pointer; transition: all 0.3s; width: 100%; }
+    .action-button:hover { background: #0b5ed7; transform: scale(1.02); }
     .action-button:disabled { background: #ccc; cursor: not-allowed; transform: none; }
     
     /* Carte interactive */
-    #map-container { display: block; margin-top: 1rem; border-radius: 8px; overflow: hidden; box-shadow: 0 2px 6px rgba(0,0,0,0.1); }
+    #map-container { display: none; margin-top: 1rem; border-radius: 8px; overflow: hidden; box-shadow: 0 2px 6px rgba(0,0,0,0.1); }
     #map { height: 300px; width: 100%; }
     .map-fullwidth{margin-left:calc(50% - 50vw);margin-right:calc(50% - 50vw);width:100vw;}
     
     /* Coordonnées sélectionnées */
-    .coordinates-display { display: none; margin-top: 1rem; padding: 1rem; background: rgba(56, 142, 60, 0.1); border-radius: 6px; text-align: center; }
+    .coordinates-display { display: none; margin-top: 1rem; padding: 1rem; background: rgba(13, 110, 253, 0.1); border-radius: 6px; text-align: center; }
     .coordinates-display span { font-weight: 600; color: var(--primary); }
     
     /* Résultats */
@@ -66,7 +67,7 @@
     
     @media (prefers-color-scheme:dark) {
       :root{--bg:#181a1b;--card:#262b2f;--border:#333;--text:#ececec}
-      .coordinates-display { background: rgba(56, 142, 60, 0.2); }
+      .coordinates-display { background: rgba(13, 110, 253, 0.2); }
       .map-instruction { background: rgba(255, 255, 255, 0.15); }
     }
     #theme-toggle{background:none;border:none;cursor:pointer;font-size:1.2rem;color:var(--text);padding:0 1rem;}
@@ -86,12 +87,10 @@
   </nav>
 
   <div class="main-content">
-    <h1>Contexte environnemental</h1>
     
     <div class="location-options">
       <!-- Option 1: Géolocalisation -->
       <div class="location-card">
-        <h2><span class="icon">📍</span>Utiliser ma position actuelle</h2>
         <button class="action-button" id="use-geolocation">
           Utiliser ma localisation
         </button>
@@ -99,11 +98,10 @@
       
       <!-- Option 2: Sélection sur carte -->
       <div class="location-card">
-        <h2><span class="icon">🗺️</span>Choisir un endroit sur la carte</h2>
         <button class="action-button" id="choose-on-map">
-          Fermer la carte
+          Ouvrir la carte
         </button>
-        
+
         <div id="map-container">
           <div class="map-instruction" id="map-instruction">
             Cliquez longuement pour sélectionner un point
@@ -123,7 +121,6 @@
 
       <!-- Option 3: Recherche par adresse -->
       <div class="location-card">
-        <h2><span class="icon">🔎</span>Rechercher une adresse</h2>
         <input type="text" id="address-input" placeholder="Saisissez une adresse"
                style="padding:8px;border:1px solid var(--border);border-radius:4px;width:100%;margin-bottom:.5rem;">
         <button class="action-button" id="search-address">Rechercher</button>


### PR DESCRIPTION
## Summary
- switch the environmental context page to a blue theme
- compact the layout so only the geolocation, map and address search buttons remain visible
- hide the map by default and adjust styles for smaller gaps

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684efffb0d58832c9337ec46f41d2502