### PR TITLE
Modify default checkbox behavior for similar species

### DIFF
--- a/app.js
+++ b/app.js
@@ -754,7 +754,7 @@ function showSimilarSpeciesButton(speciesName) {
     if (extras.length) {
       extras.forEach(n => {
         if (!displayedItems.some(it => it.species.scientificNameWithoutAuthor === n)) {
-          displayedItems.push({ score: 0, species: { scientificNameWithoutAuthor: n }, autoCheck: true });
+          displayedItems.push({ score: 0, species: { scientificNameWithoutAuthor: n }, autoCheck: false });
         }
       });
       buildTable(displayedItems);


### PR DESCRIPTION
## Summary
- disable auto-check when adding suggested species via the "Montrer des espèces similaires" button

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684fa6dd8e04832cab34a9c3a04cb7e3