### PR TITLE
Compact mobile layout for GBIF map viewer

### DIFF
--- a/carte_interactive/map_view.html
+++ b/carte_interactive/map_view.html
@@ -10,11 +10,6 @@
     <link rel="stylesheet" href="style.css">
 </head>
 <body>
-
-    <header>
-        <h1>Visualisateur d'occurrences d'espèces (GBIF)</h1>
-    </header>
-
     <main>
         <div id="controls">
             <input type="text" id="speciesInput" placeholder="Nom scientifique de l'espèce (ex: Lamium purpureum)">

--- a/carte_interactive/style.css
+++ b/carte_interactive/style.css
@@ -33,8 +33,8 @@ main {
 /* Panneau de contrôle */
 #controls {
     display: flex;
-    gap: 10px;
-    padding: 15px 15px 5px 15px;
+    gap: 5px;
+    padding: 8px 10px 4px 10px;
     background-color: #ffffff;
     border-bottom: 1px solid #ddd;
     flex-wrap: wrap;
@@ -84,8 +84,8 @@ main {
 #radius-control {
     display: flex;
     align-items: center;
-    gap: 10px;
-    padding: 5px 15px 10px 15px;
+    gap: 5px;
+    padding: 4px 10px 6px 10px;
     background-color: #ffffff;
     border-bottom: 1px solid #ddd;
 }
@@ -105,12 +105,12 @@ main {
     display: flex;
     justify-content: center;
     align-items: center;
-    gap: 10px;
-    padding: 10px;
+    gap: 8px;
+    padding: 5px;
     background-color: #f8f9fa;
     font-size: 0.9em;
     color: #333;
-    min-height: 25px;
+    min-height: 20px;
 }
 
 /* --- MODIFICATION : Légende des espèces en liste verticale --- */
@@ -119,7 +119,7 @@ main {
     flex-direction: column; /* Affichage en colonne */
     align-items: flex-start; /* Alignement à gauche */
     gap: 5px; /* Espacement réduit pour une liste */
-    padding: 10px;
+    padding: 5px;
     background-color: #ffffff;
     border-bottom: 1px solid #ddd;
     font-size: 0.9em;


### PR DESCRIPTION
## Summary
- remove page header on the GBIF occurrence viewer map
- tighten padding on the search controls, radius selector, status bar and legend so the map fills more vertical space

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684fa78b61a0832c8d14045b3eb576e9