### PR TITLE
Improve mobile spacing in GBIF map view

### DIFF
--- a/carte_interactive/style.css
+++ b/carte_interactive/style.css
@@ -125,6 +125,36 @@ main {
     font-size: 0.9em;
 }
 
+@media (max-width: 600px) {
+    #controls {
+        gap: 3px;
+        padding: 4px 6px;
+    }
+    #speciesInput {
+        padding: 6px;
+        font-size: 0.9em;
+    }
+    #searchButton,
+    #clearButton {
+        padding: 6px 10px;
+        font-size: 0.9em;
+    }
+    #radius-control {
+        gap: 3px;
+        padding: 2px 6px;
+        font-size: 0.9em;
+    }
+    #status-container {
+        padding: 3px;
+        font-size: 0.8em;
+    }
+    #legend {
+        gap: 3px;
+        padding: 3px 6px;
+        font-size: 0.8em;
+    }
+}
+
 .legend-item {
     display: flex;
     align-items: center;


### PR DESCRIPTION
## Summary
- make control panel more compact on small screens for the GBIF map view

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684faa4e7164832cbfc3253832f4265a