### PR TITLE
Add user marker on localisation map

### DIFF
--- a/carte_interactive/script.js
+++ b/carte_interactive/script.js
@@ -175,6 +175,11 @@ document.addEventListener('DOMContentLoaded', () => {
                     fill: false
                 }).addTo(mainLayerGroup);
 
+                const userIcon = createColoredIcon('blue');
+                L.marker([coords.latitude, coords.longitude], { icon: userIcon })
+                    .bindPopup('Votre position')
+                    .addTo(mainLayerGroup);
+
                 map.fitBounds(searchCircle.getBounds());
                 
                 const searchPromises = speciesList.map((name, index) =>


### PR DESCRIPTION
## Summary
- display user's position on the localisation map with a blue marker

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684fb09551b8832cbf3a28311c954a10