### PR TITLE
Implement modal popup on double-click

### DIFF
--- a/app.js
+++ b/app.js
@@ -699,21 +699,19 @@ function buildTable(items){
         return;
       }
 
+  };
+  const handleWrapDblClick = (e) => {
       const targetCell = e.target.closest('.text-popup-trigger');
       if (targetCell) {
           e.preventDefault();
-          const infoPanel = document.getElementById('info-panel');
-          if (infoPanel) {
-              const title = targetCell.dataset.title || '';
-              const fullText = decodeURIComponent(targetCell.dataset.fulltext);
-              infoPanel.innerHTML = `<h3 style="margin-top:0">${title}</h3><p>${fullText}</p>`;
-              infoPanel.style.display = 'block';
-              infoPanel.scrollIntoView({behavior:'smooth', block:'start'});
-          }
+          const title = targetCell.dataset.title || '';
+          const fullText = decodeURIComponent(targetCell.dataset.fulltext);
+          showInfoModal(title, fullText);
       }
   };
   wrap.addEventListener('click', handleWrapClick);
   wrap.addEventListener('touchend', handleWrapClick);
+  wrap.addEventListener('dblclick', handleWrapDblClick);
 }
 
 function buildCards(items){

--- a/organ.html
+++ b/organ.html
@@ -72,7 +72,6 @@
       .search-inline{display:flex;gap:.5rem;align-items:center;width:90vw;max-width:450px;margin-left:auto;margin-bottom:1rem;}
       .search-inline input[type="search"]{flex-grow:1;padding:10px;border:1px solid var(--border);border-radius:6px;font-size:1rem;margin:0;background-color:#fff;}
 
-    .info-panel{display:none;padding:1rem;background:var(--card);border:1px solid var(--border);border-radius:6px;margin-top:1rem;}
 
     #similar-btn-area { text-align: center; margin-top: 0; }
     #similar-btn {
@@ -125,6 +124,5 @@
   </div>
   <div id="results"></div>
   <div id="similar-btn-area"></div>
-  <div id="info-panel" class="info-panel"></div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- remove old info panel markup and styles
- show species info in existing modal on double-click
- keep single click for copying latin names

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6851951e86cc832cb33a417a8a90ece3