### PR TITLE
Handle drag events when opening detail pop‑ups

### DIFF
--- a/app.js
+++ b/app.js
@@ -724,8 +724,19 @@ function buildTable(items){
 
   };
 
-  wrap.addEventListener('click', handleWrapClick);
-  wrap.addEventListener('touchend', handleWrapClick);
+  let startX = 0;
+  let startY = 0;
+  wrap.addEventListener('pointerdown', e => {
+      startX = e.clientX;
+      startY = e.clientY;
+  });
+  wrap.addEventListener('pointerup', e => {
+      const dx = Math.abs(e.clientX - startX);
+      const dy = Math.abs(e.clientY - startY);
+      if (dx < 5 && dy < 5) {
+          handleWrapClick(e);
+      }
+  });
 
   const overlay = document.getElementById('popup-overlay');
   if (overlay) {


### PR DESCRIPTION
## Summary
- prevent unwanted pop‑ups while dragging the summary table

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6851a47b70f8832cbfb03ff3e2c0c98c