### PR TITLE
Add double-click requirement for info popup

### DIFF
--- a/app.js
+++ b/app.js
@@ -747,6 +747,8 @@ function buildTable(items){
 
   let startX = 0;
   let startY = 0;
+  let lastClickTime = 0;
+  let lastClickTarget = null;
   wrap.addEventListener('pointerdown', e => {
       startX = e.clientX;
       startY = e.clientY;
@@ -755,7 +757,25 @@ function buildTable(items){
       const dx = Math.abs(e.clientX - startX);
       const dy = Math.abs(e.clientY - startY);
       if (dx < 5 && dy < 5) {
-          handleWrapClick(e);
+          const trigger = e.target.closest('.text-popup-trigger');
+          const now = performance.now();
+          if (trigger) {
+              if (lastClickTarget === trigger && (now - lastClickTime) < 400) {
+                  handleWrapClick(e);
+                  lastClickTarget = null;
+                  lastClickTime = 0;
+              } else {
+                  lastClickTarget = trigger;
+                  lastClickTime = now;
+              }
+          } else {
+              handleWrapClick(e);
+              lastClickTarget = null;
+              lastClickTime = 0;
+          }
+      } else {
+          lastClickTarget = null;
+          lastClickTime = 0;
       }
   });
 


### PR DESCRIPTION
## Summary
- prevent accidental popup display when scrolling horizontally
- display info popup only on a double click without movement

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6852541b6620832ca4c1a4d3680bb528