### PR TITLE
Fix popup overlay missing on home page

### DIFF
--- a/index.html
+++ b/index.html
@@ -140,6 +140,44 @@
       background-color: #fb8c00;
     }
 
+    /* Styles pour l'affichage des textes complets */
+    .text-popup-trigger {
+      display: -webkit-box;
+      -webkit-line-clamp: 3;
+      -webkit-box-orient: vertical;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      cursor: zoom-in;
+      max-height: 4.8em;
+      -webkit-user-select: none;
+      -moz-user-select: none;
+      -ms-user-select: none;
+      user-select: none;
+    }
+
+    .popup-overlay {
+      position: fixed;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+      background: rgba(0,0,0,0.5);
+      display: none;
+      align-items: center;
+      justify-content: center;
+      z-index: 1000;
+    }
+
+    .popup-content {
+      max-width: 90%;
+      max-height: 80%;
+      overflow: auto;
+      background: var(--card);
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      padding: 1rem;
+    }
+
     @media (prefers-color-scheme:dark){ 
       :root{--bg:#181a1b;--card:#262b2f;--border:#333;--text:#ececec} 
       .tabs-container { background: var(--card); }
@@ -185,6 +223,9 @@
         </div>
         <div id="results"></div>
         <div id="similar-btn-area"></div>
+        <div id="popup-overlay" class="popup-overlay">
+            <div id="popup-content" class="popup-content"></div>
+        </div>
     </div>
 
     <div id="synthesis-modal" class="synthesis-modal-overlay">


### PR DESCRIPTION
## Summary
- add popup overlay container and styles to index.html
- ensure Latin names copy to clipboard with overlay on main page

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685285a7cacc832c88c1dde96c950030