### PR TITLE
Upgrade Gemini model to 2.5 flash

### DIFF
--- a/app.js
+++ b/app.js
@@ -9,7 +9,7 @@ const MAX_MULTI_IMAGES = 5;
 // NOUVEAU : Ajout des clés et points d'accès pour les API Google
 const GEMINI_API_KEY = "AIzaSyDDv4amCchpTXGqz6FGuY8mxPClkw-uwMs";
 const TTS_API_KEY = "AIzaSyCsmQ_n_JtrA1Ev2GkOZeldYsAmHpJvhZY";
-const GEMINI_ENDPOINT = `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key=${GEMINI_API_KEY}`;
+const GEMINI_ENDPOINT = `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent?key=${GEMINI_API_KEY}`;
 const TTS_ENDPOINT = `https://texttospeech.googleapis.com/v1/text:synthesize?key=${TTS_API_KEY}`;
 
 


### PR DESCRIPTION
## Summary
- bump the Gemini model reference from `gemini-2.0-flash` to `gemini-2.5-flash`

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_68533810a880832c84a013c8bafefcfc