### PR TITLE
Add OpenTopoMap base layer with fallback

### DIFF
--- a/contexte.js
+++ b/contexte.js
@@ -356,10 +356,20 @@ async function displayInteractiveEnvMap() {
     // Initialisation ou réinitialisation de la carte
     if (!envMap) {
         envMap = L.map('env-map').setView([selectedLat, selectedLon], 11);
-        L.tileLayer('https://{s}.tile.opentopomap.org/{z}/{x}/{y}.png', {
+        const topoLayer = L.tileLayer('https://{s}.tile.opentopomap.org/{z}/{x}/{y}.png', {
             attribution: '© OpenStreetMap contributors, SRTM | Map style: © OpenTopoMap (CC-BY-SA)',
-            maxZoom: 17
+            maxZoom: 17,
+            crossOrigin: true
         }).addTo(envMap);
+        topoLayer.on('tileerror', () => {
+            if (envMap.hasLayer(topoLayer)) {
+                envMap.removeLayer(topoLayer);
+                L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+                    attribution: '© OpenStreetMap contributors',
+                    maxZoom: 19
+                }).addTo(envMap);
+            }
+        });
         enableGoogleMapsLongPress(envMap);
     } else {
         envMap.setView([selectedLat, selectedLon], 11);


### PR DESCRIPTION
## Summary
- ensure `contexte.js` uses OpenTopoMap tiles for the environmental map
- if OpenTopoMap tiles fail to load, fall back to OpenStreetMap

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68533e8af1bc832ca28a86b7b1440e16