### PR TITLE
Add OpenTopoMap base layer for context map

### DIFF
--- a/contexte.js
+++ b/contexte.js
@@ -207,11 +207,21 @@ function toggleMap() {
 function initializeMap() {
 	const defaultLat = 45.188529;
 	const defaultLon = 5.724524;
-	map = L.map('map').setView([defaultLat, defaultLon], 13);
-	L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-		attribution: '© OpenStreetMap contributors',
-		maxZoom: 19
-	}).addTo(map);
+        map = L.map('map').setView([defaultLat, defaultLon], 13);
+        const topoLayer = L.tileLayer('https://{s}.tile.opentopomap.org/{z}/{x}/{y}.png', {
+                attribution: '© OpenStreetMap contributors, SRTM | Map style: © OpenTopoMap (CC-BY-SA)',
+                maxZoom: 17,
+                crossOrigin: true
+        }).addTo(map);
+        topoLayer.on('tileerror', () => {
+                if (map.hasLayer(topoLayer)) {
+                        map.removeLayer(topoLayer);
+                        L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+                                attribution: '© OpenStreetMap contributors',
+                                maxZoom: 19
+                        }).addTo(map);
+                }
+        });
 	
 	let pressTimer;
 	let isPressing = false;


### PR DESCRIPTION
## Summary
- use OpenTopoMap for the context map's selection view and fall back to OSM on error

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68534149c304832ca49ebd6a91a3566f