### PR TITLE
Fix Flora Helvetica link to open species page

### DIFF
--- a/app.js
+++ b/app.js
@@ -95,10 +95,7 @@ const isIOS = () => typeof navigator !== 'undefined' &&
 const floraHelveticaUrl = n => {
   const code = cdRef(n);
   const base = code ? `species/${code}` : `species?name=${encodeURIComponent(n)}`;
-  if (isIOS()) {
-    return `florahelvetica://${base}`;
-  }
-  return `intent://${base}#Intent;scheme=florahelvetica;end`;
+  return `florahelvetica://${base}`;
 };
 
 function enableDragScroll(el) {


### PR DESCRIPTION
## Summary
- simplify `floraHelveticaUrl` so links open the Flora Helvetica app directly

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6853d71aef80832cae4bd549a1c401ac