### PR TITLE
Fix Android link for Flora Helvetica FR

### DIFF
--- a/app.js
+++ b/app.js
@@ -91,10 +91,15 @@ const aura       = c => `https://atlas.biodiversite-auvergne-rhone-alpes.fr/espe
 const pfaf       = n => `https://pfaf.org/user/Plant.aspx?LatinName=${encodeURIComponent(n).replace(/%20/g, '+')}`;
 const isIOS = () => typeof navigator !== 'undefined' &&
   /iPad|iPhone|iPod/.test(navigator.userAgent);
+const isAndroid = () => typeof navigator !== 'undefined' && /Android/.test(navigator.userAgent);
+const floraHelveticaPackage = 'de.haupt.florahelvetica.pro.fr';
 
 const floraHelveticaUrl = n => {
   const code = cdRef(n);
   const base = code ? `species/${code}` : `species?name=${encodeURIComponent(n)}`;
+  if (isAndroid()) {
+    return `intent://${base}#Intent;scheme=florahelvetica;package=${floraHelveticaPackage};end`;
+  }
   return `florahelvetica://${base}`;
 };
 


### PR DESCRIPTION
## Summary
- update `floraHelveticaUrl` so Android uses correct deep link for Flora Helvetica FR

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6853f9432990832c821310c05186109f