### PR TITLE
Ajout couches WFS et proxy générique

### DIFF
--- a/netlify/functions/generic-proxy.js
+++ b/netlify/functions/generic-proxy.js
@@ -1,0 +1,32 @@
+const fetch = (...args) => import('node-fetch').then(({default: f}) => f(...args));
+
+exports.handler = async function(event) {
+  try {
+    const params = event.queryStringParameters || {};
+    const targetService = params.targetService;
+    if (!targetService) {
+      return { statusCode: 400, body: 'Missing targetService parameter' };
+    }
+    const query = { ...params };
+    delete query.targetService;
+    const search = new URLSearchParams(query).toString();
+    const finalUrl = targetService + (search ? `?${search}` : '');
+
+    const response = await fetch(finalUrl);
+    const contentType = response.headers.get('content-type');
+    const buffer = await response.buffer();
+    if (!response.ok) {
+      return { statusCode: response.status, body: buffer.toString() };
+    }
+
+    return {
+      statusCode: 200,
+      headers: { 'Content-Type': contentType },
+      body: buffer.toString('base64'),
+      isBase64Encoded: true
+    };
+  } catch (err) {
+    console.error('Generic proxy error', err);
+    return { statusCode: 500, body: 'Internal server error' };
+  }
+};


### PR DESCRIPTION
## Summary
- support WFS requests in `fetchAndDisplayApiLayer`
- gestion des couches désactivées dans la carte
- ajout des couches APPB et Zones humides
- désactivation explicite pour ENS et Pelouses sèches
- création d'une fonction `generic-proxy` pour requêtes WFS externes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685465498a54832cbd23591c6bdfbd6b