### PR TITLE
Handle relative Biodiv'AURA image paths

### DIFF
--- a/__tests__/aura-images.test.js
+++ b/__tests__/aura-images.test.js
@@ -1,0 +1,16 @@
+const { loadAuraHandler, mockFetch } = require('../test-utils');
+
+describe('aura-images handler', () => {
+  test('converts relative urls to absolute', async () => {
+    const html = '<img src="/img/pic1.png"><img src="http://example.com/pic2.png">';
+    const fetchMock = mockFetch(html);
+    const handler = loadAuraHandler(fetchMock);
+    const res = await handler({ queryStringParameters: { cd: '42' } });
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.images).toEqual([
+      'https://atlas.biodiversite-auvergne-rhone-alpes.fr/img/pic1.png',
+      'http://example.com/pic2.png'
+    ]);
+  });
+});

--- a/netlify/functions/aura-images.js
+++ b/netlify/functions/aura-images.js
@@ -17,7 +17,11 @@ exports.handler = async function(event) {
         const images = [];
         let m;
         while ((m = regex.exec(html)) !== null) {
-            const src = m[1];
+            let src = m[1];
+            if (!/^https?:\/\//.test(src)) {
+                const prefix = 'https://atlas.biodiversite-auvergne-rhone-alpes.fr';
+                src = prefix + (src.startsWith('/') ? '' : '/') + src;
+            }
             if (!images.includes(src)) images.push(src);
         }
         return { statusCode: 200, headers: {'Content-Type':'application/json'}, body: JSON.stringify({ images }) };

--- a/test-utils.js
+++ b/test-utils.js
@@ -45,6 +45,19 @@ function loadHandler(mockFetch) {
   return context.exports.handler;
 }
 
+function loadAuraHandler(mockFetch) {
+  const code = fs.readFileSync('netlify/functions/aura-images.js', 'utf-8');
+  const patched = code.replace(
+    /const fetch = \(\.\.\.args\) => import\(['"]node-fetch['"]\)\.then\(\(\{default: f\}\) => f\(\.\.\.args\)\);/,
+    'const fetch = (...args) => global.__fetch(...args);'
+  );
+  const context = { require, console, exports: {}, __fetch: mockFetch };
+  context.global = context;
+  vm.createContext(context);
+  vm.runInContext(patched, context);
+  return context.exports.handler;
+}
+
 function mockFetch(html) {
   return jest.fn().mockResolvedValue({
     ok: true,
@@ -52,4 +65,4 @@ function mockFetch(html) {
   });
 }
 
-module.exports = { loadApp, loadHandler, mockFetch };
+module.exports = { loadApp, loadHandler, loadAuraHandler, mockFetch };


### PR DESCRIPTION
## Summary
- normalize image URLs in `aura-images.js`
- add tests for Biodiv'AURA handler
- expose new `loadAuraHandler` helper for tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68554f47ac4c832c92fdeead48ec4f84