### PR TITLE
Fix BiodivAURA image pop-up

### DIFF
--- a/__tests__/aura-images.test.js
+++ b/__tests__/aura-images.test.js
@@ -2,7 +2,7 @@ const { loadAuraHandler, mockFetch } = require('../test-utils');
 
 describe('aura-images handler', () => {
   test('converts relative urls to absolute', async () => {
-    const html = '<img src="/img/pic1.jpg"><img src="http://example.com/pic2.jpeg">';
+    const html = '<img src="/img/pic1.jpg"><img src="http://example.com/pic2.png">';
     const fetchMock = mockFetch(html);
     const handler = loadAuraHandler(fetchMock);
     const res = await handler({ queryStringParameters: { cd: '42' } });
@@ -10,7 +10,18 @@ describe('aura-images handler', () => {
     const body = JSON.parse(res.body);
     expect(body.images).toEqual([
       'https://atlas.biodiversite-auvergne-rhone-alpes.fr/img/pic1.jpg',
-      'http://example.com/pic2.jpeg'
+      'http://example.com/pic2.png'
+    ]);
+  });
+
+  test('filters out logo images', async () => {
+    const html = '<img src="/img/logo.png"><img src="/photos/plant1.jpg">';
+    const fetchMock = mockFetch(html);
+    const handler = loadAuraHandler(fetchMock);
+    const res = await handler({ queryStringParameters: { cd: '1' } });
+    const body = JSON.parse(res.body);
+    expect(body.images).toEqual([
+      'https://atlas.biodiversite-auvergne-rhone-alpes.fr/photos/plant1.jpg'
     ]);
   });
 });

--- a/app.js
+++ b/app.js
@@ -134,7 +134,7 @@ async function fetchAuraImages(cd) {
     const res = await fetch(`/.netlify/functions/aura-images?cd=${cd}`);
     if (!res.ok) return [];
     const data = await res.json();
-    return Array.isArray(data.images) ? data.images.filter(u => u.endsWith('.png')) : [];
+    return Array.isArray(data.images) ? data.images.filter(u => /\.jpe?g$|\.png$/i.test(u)) : [];
   } catch (err) {
     console.error('fetchAuraImages error', err);
     return [];

--- a/netlify/functions/aura-images.js
+++ b/netlify/functions/aura-images.js
@@ -13,7 +13,7 @@ exports.handler = async function(event) {
             return { statusCode: res.status, body: txt };
         }
         const html = await res.text();
-        const regex = /<img[^>]+src="([^"]+\.jpe?g)"/ig;
+        const regex = /<img[^>]+src="([^"]+\.(?:jpe?g|png))"[^>]*>/ig;
         const images = [];
         let m;
         while ((m = regex.exec(html)) !== null) {
@@ -22,6 +22,7 @@ exports.handler = async function(event) {
                 const prefix = 'https://atlas.biodiversite-auvergne-rhone-alpes.fr';
                 src = prefix + (src.startsWith('/') ? '' : '/') + src;
             }
+            if (/logo|icone?|icon|favicon/i.test(src)) continue;
             if (!images.includes(src)) images.push(src);
         }
         return { statusCode: 200, headers: {'Content-Type':'application/json'}, body: JSON.stringify({ images }) };


### PR DESCRIPTION
## Summary
- show BiodivAURA photos without logos
- support JPEG and PNG images in extraction
- expand tests for new filtering logic

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68558d6ffcf4832c90485d3c07578962