### PR TITLE
Réorganise deux colonnes du tableau

### DIFF
--- a/app.js
+++ b/app.js
@@ -689,8 +689,6 @@ function buildTable(items){
               <td class="col-nom-latin" data-latin="${displaySci}">${displaySci}<br><span class="score">(${pct})</span></td>
               <td class="col-link">${floreAlpesLink}</td>
               <td class="col-link">${floraGallicaLink}</td>
-              <td class="col-link">${regalVegetalLink}</td>
-              <td class="col-link">${floreMedLink}</td>
               <td class="col-link">${linkIcon(cd && inpnStatut(cd), "INPN.png", "INPN", "small-logo")}</td>
               <td class="col-criteres">
                 <div class="text-popup-trigger" data-title="Critères physiologiques" data-fulltext="${encodeURIComponent(crit)}">${crit}</div>
@@ -706,11 +704,13 @@ function buildTable(items){
               <td class="col-link">${floraHelveticaLink}</td>
               <td class="col-link"><a href="#" onclick="handleSynthesisClick(event, this, '${escapedSci}')"><img src="assets/Audio.png" alt="Audio" class="logo-icon"></a></td>
               <td class="col-link">${linkIcon(pfaf(sci), "PFAF.png", "PFAF")}</td>
+              <td class="col-link">${regalVegetalLink}</td>
+              <td class="col-link">${floreMedLink}</td>
               <td class="col-image" data-cd="${cd || ''}"></td>
             </tr>`;
   }).join("");
 
-  const headerHtml = `<tr><th><button type="button" id="toggle-select-btn" class="select-toggle-btn">Tout sélectionner</button></th><th>Nom latin (score %)</th><th>FloreAlpes</th><th>Flora Gallica</th><th>Régal Végétal</th><th>Flore Méd</th><th>INPN statut</th><th>Critères physiologiques</th><th>Écologie</th><th>Physionomie</th><th>Biodiv'AURA</th><th>Info Flora</th><th>Flora Helvetica</th><th>Fiche synthèse</th><th>PFAF</th><th>Image</th></tr>`;
+  const headerHtml = `<tr><th><button type="button" id="toggle-select-btn" class="select-toggle-btn">Tout sélectionner</button></th><th>Nom latin (score %)</th><th>FloreAlpes</th><th>Flora Gallica</th><th>INPN statut</th><th>Critères physiologiques</th><th>Écologie</th><th>Physionomie</th><th>Biodiv'AURA</th><th>Info Flora</th><th>Flora Helvetica</th><th>Fiche synthèse</th><th>PFAF</th><th>Régal Végétal</th><th>Flore Méd</th><th>Image</th></tr>`;
   
   wrap.innerHTML = `<div class="table-wrapper"><table><thead>${headerHtml}</thead><tbody>${rows}</tbody></table></div><div id="comparison-footer" style="padding-top: 1rem; text-align: center;"></div><div id="comparison-results-container" style="display:none;"></div>`;
   enableDragScroll(wrap);


### PR DESCRIPTION
## Summary
- move "Flore Méd" and "Régal Végétal" columns after `PFAF`

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6857d0ee51c8832c8b97e974c27625f3