### PR TITLE
Prevent accidental popups on drag

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,8 +101,9 @@ This launches the Jest test suite which validates the helper utilities and the
   quick reference.
 - Clicking a species name copies the Latin name to the clipboard.
 - Clicking a cell in the "Critères physiologiques", "Écologie" or "Physionomie"
-  columns now opens an overlay pop‑up with the full text. Clicking outside the
-  pop‑up closes it instantly.
+  columns opens an overlay pop‑up with the full text **only after a static
+  click**. A swipe used to scroll the table will no longer trigger the pop‑up.
+  Clicking outside the pop‑up closes it instantly.
 - Google Gemini can generate a comparison table with optional text‑to‑speech
   playback.
 - When a single species is searched, a button under the results can retrieve

--- a/app.js
+++ b/app.js
@@ -820,6 +820,25 @@ function buildTable(items){
       });
   }
 
+  let startX, startY, moved = false;
+  const MOVE_THRESHOLD = 6;
+  const startPoint = ev => {
+      const t = ev.touches ? ev.touches[0] : ev;
+      startX = t.clientX;
+      startY = t.clientY;
+      moved = false;
+  };
+  const checkMove = ev => {
+      const t = ev.touches ? ev.touches[0] : ev;
+      if (Math.abs(t.clientX - startX) > MOVE_THRESHOLD || Math.abs(t.clientY - startY) > MOVE_THRESHOLD) {
+          moved = true;
+      }
+  };
+  wrap.addEventListener('pointerdown', startPoint);
+  wrap.addEventListener('pointermove', checkMove);
+  wrap.addEventListener('touchstart', startPoint);
+  wrap.addEventListener('touchmove', checkMove);
+
   wrap.addEventListener('change', (e) => {
       if (e.target.classList.contains('species-checkbox')) {
           updateCompareVisibility();
@@ -878,8 +897,12 @@ function buildTable(items){
 
   };
 
-  wrap.addEventListener('click', handleWrapClick);
-  wrap.addEventListener('touchend', handleWrapClick);
+  const safeClick = e => {
+      if (moved) { moved = false; return; }
+      handleWrapClick(e);
+  };
+  wrap.addEventListener('click', safeClick);
+  wrap.addEventListener('touchend', safeClick);
 
   const overlay = document.getElementById('popup-overlay');
   if (overlay) {


### PR DESCRIPTION
## Summary
- only show popup when click is static, not during scroll
- document this behaviour in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6857dd467680832c8ce6e5f423f09f49