### PR TITLE
Add phenology column to summary table

### DIFF
--- a/__tests__/data.test.js
+++ b/__tests__/data.test.js
@@ -3,8 +3,8 @@ const vm = require('vm');
 
 function loadAppWithExports(extraCtx = {}) {
   const ctx = loadApp(extraCtx);
-  vm.runInContext('globalThis.__extract = { taxref, ecology, trigramIndex, criteres, physionomie };', ctx);
-  vm.runInContext('globalThis.__cdRef = cdRef; globalThis.__ecolOf = ecolOf;', ctx);
+  vm.runInContext('globalThis.__extract = { taxref, ecology, trigramIndex, criteres, physionomie, phenologie };', ctx);
+  vm.runInContext('globalThis.__cdRef = cdRef; globalThis.__ecolOf = ecolOf; globalThis.__phenoOf = phenoOf;', ctx);
   return ctx;
 }
 
@@ -26,6 +26,9 @@ describe('data loading', () => {
       if (url === 'Physionomie.csv') {
         return Promise.resolve({ ok: true, text: () => Promise.resolve('Abies alba;phy\n') });
       }
+      if (url === 'Phenologie.csv') {
+        return Promise.resolve({ ok: true, text: () => Promise.resolve('Abies alba;4-5\n') });
+      }
       return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
     });
     const ctx = loadAppWithExports({ fetch: fetchMock });
@@ -38,6 +41,8 @@ describe('data loading', () => {
     const key = ctx.norm('Abies alba');
     expect(ctx.__extract.criteres[key]).toBe('desc');
     expect(ctx.__extract.physionomie[key]).toBe('phy');
+    expect(ctx.__extract.phenologie[key]).toBe('4-5');
+    expect(ctx.__phenoOf('Abies alba')).toBe('4-5');
   });
 });
 

--- a/app.js
+++ b/app.js
@@ -27,6 +27,7 @@ let floreMedToc = {}; // Variable pour la table des matières de Flore Méd
 let floreAlpesIndex = {}; 
 let criteres = {};
 let physionomie = {};
+let phenologie = {};
 let userLocation = { latitude: 45.188529, longitude: 5.724524 };
 
 let displayedItems = [];
@@ -52,6 +53,10 @@ function loadData() {
     fetch("Physionomie.csv").then(r => r.text()).then(t => parseCsv(t).forEach(row => {
       const [name, desc] = row;
       if (name) physionomie[norm(name)] = desc;
+    })),
+    fetch("Phenologie.csv").then(r => r.text()).then(t => parseCsv(t).forEach(row => {
+      const [name, pheno] = row;
+      if (name) phenologie[norm(name)] = pheno;
     }))
   ]).then(() => { taxrefNames.sort(); console.log("Données prêtes."); })
     .catch(err => {
@@ -84,6 +89,7 @@ const cdRef = n => taxref[norm(n)];
 const ecolOf = n => ecology[norm(n)] || "—";
 const criteresOf = n => criteres[norm(n)] || "—";
 const physioOf = n => physionomie[norm(n)] || "—";
+const phenoOf = n => phenologie[norm(n)] || "—";
 const slug = n => norm(n).replace(/ /g, "-");
 
 function parseCsv(text) {
@@ -681,6 +687,7 @@ function buildTable(items){
     const eco  = ecolOf(sci);
     const crit = criteresOf(sci);
     const phys = physioOf(sci);
+    const pheno = phenoOf(sci);
     const genus = sci.split(' ')[0].toLowerCase();
     
     const tocEntryFloraGallica = floraToc[genus];
@@ -739,6 +746,9 @@ function buildTable(items){
               <td class="col-physionomie">
                 <div class="text-popup-trigger" data-title="Physionomie" data-fulltext="${encodeURIComponent(phys)}">${phys}</div>
               </td>
+              <td class="col-phenologie">
+                <div class="text-popup-trigger" data-title="Phénologie" data-fulltext="${encodeURIComponent(pheno)}">${pheno}</div>
+              </td>
               <td class="col-link">${linkIcon(cd && aura(cd), "Biodiv'AURA.png", "Biodiv'AURA")}</td>
               <td class="col-link">${linkIcon(infoFlora(sci), "Info Flora.png", "Info Flora")}</td>
               <td class="col-link">${floraHelveticaLink}</td>
@@ -750,7 +760,7 @@ function buildTable(items){
             </tr>`;
   }).join("");
 
-  const headerHtml = `<tr><th><button type="button" id="toggle-select-btn" class="select-toggle-btn">Tout sélectionner</button></th><th>Nom latin (score %)</th><th>FloreAlpes</th><th>Flora Gallica</th><th>INPN statut</th><th>Critères physiologiques</th><th>Écologie</th><th>Physionomie</th><th>Biodiv'AURA</th><th>Info Flora</th><th>Flora Helvetica</th><th>Fiche synthèse</th><th>PFAF</th><th>Régal Végétal</th><th>Flore Méd</th><th>Image</th></tr>`;
+  const headerHtml = `<tr><th><button type="button" id="toggle-select-btn" class="select-toggle-btn">Tout sélectionner</button></th><th>Nom latin (score %)</th><th>FloreAlpes</th><th>Flora Gallica</th><th>INPN statut</th><th>Critères physiologiques</th><th>Écologie</th><th>Physionomie</th><th>Phénologie</th><th>Biodiv'AURA</th><th>Info Flora</th><th>Flora Helvetica</th><th>Fiche synthèse</th><th>PFAF</th><th>Régal Végétal</th><th>Flore Méd</th><th>Image</th></tr>`;
   
   wrap.innerHTML = `<div class="table-wrapper"><table><thead>${headerHtml}</thead><tbody>${rows}</tbody></table></div><div id="comparison-footer" style="padding-top: 1rem; text-align: center;"></div><div id="comparison-results-container" style="display:none;"></div>`;
   enableDragScroll(wrap);

--- a/index.html
+++ b/index.html
@@ -101,6 +101,7 @@
     .col-criteres { width: 22%; font-size: 0.9em; }
     .col-ecologie { width: 22%; }
     .col-physionomie { width: 22%; font-size: 0.9em; }
+    .col-phenologie { width: 10%; }
     .col-link { width: 6%; text-align: center; }
     .logo-icon { width: 24px; height: auto; }
     .small-logo { height: 24px; width: auto; }
@@ -210,6 +211,7 @@
       .tabs-container { background: var(--card); }
       .tab:hover { background: rgba(56, 142, 60, 0.2); }
       table,details{border-color:#333} th{background:#30363c;color:#ececec} tbody tr:nth-child(odd){background-color:rgba(255,255,255,0.05);} body.home .upload-btn.logo-btn span { color: var(--text); } .option-container { background-color: rgba(38, 43, 47, 0.8); } #multi-image-list-area .image-organ-item { background-color: var(--card); border-color: var(--border); } #multi-image-list-area select { background-color: #333; color: var(--text); } .col-nom-latin .score { color:#ccc; } .col-criteres { color: #ccc; } .col-physionomie { color:#ccc; } #multi-image-list-area .delete-file-btn { color: #ff6b6b; } #multi-image-list-area .delete-file-btn:hover { color: #ff8787; } .search-inline input[type="search"] { background-color: #fff; color: #000; border-color: #555; }
+      .col-phenologie { color:#ccc; }
       .col-image { width: 80px; }
     }
   </style>

--- a/organ.html
+++ b/organ.html
@@ -41,7 +41,7 @@
     td a{color:var(--primary);text-decoration:none}
     td a:hover{text-decoration:underline}
     /* MODIFIÉ : Largeur des colonnes de texte ajustée pour la nouvelle colonne */
-    .col-criteres, .col-ecologie, .col-physionomie { width: 16%; }
+    .col-criteres, .col-ecologie, .col-physionomie, .col-phenologie { width: 16%; }
     
     .text-popup-trigger {
         display: -webkit-box;


### PR DESCRIPTION
## Summary
- load `Phenologie.csv` and map latin name to flowering period
- expose `phenoOf` helper and display phenology in results table
- style new column in light/dark themes and organ page
- adjust data loading tests for phenology data

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6857e2750214832c905f095d02a842f5